### PR TITLE
Add hidden perks and sequential brawls

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ purchased and equipped through the inventory screen. A wooden sword is also
 available for the weapon slot. Each item lists its attack (A), defense (D) and
 speed (S) bonuses.
 
+Your apartment can also be improved. While inside the Home you can buy a Comfy
+Bed, Decorations, or a Study Desk. These upgrades boost your energy recovery
+and may grant daily bonuses when you sleep.
+
+As your stats reach new milestones you earn perk points. Press **P** to open the
+Perk menu and spend these points to unlock or upgrade perks (up to level 3).
+Available perks include Gym Rat, Book Worm, Social Butterfly, Night Owl, Lucky,
+and Iron Will. Higher perk levels further improve their bonuses.
+
+Winning fights in the bar now progresses through five increasingly tough
+challengers. Defeat them all to earn the hidden **Bar Champion** perk. Owning
+every home upgrade unlocks **Home Owner**, and maxing out all other perks grants
+the secret **Perk Master** perk.
+
 
 
 The game now features simple sound effects, looping background music, and a

--- a/entities.py
+++ b/entities.py
@@ -32,7 +32,15 @@ class Player:
     clinic_shifts: int = 0
     tokens: int = 0
 
+    brawls_won: int = 0
+
     has_skateboard: bool = False
+    home_upgrades: List[str] = field(default_factory=list)
+    perk_points: int = 0
+    perk_levels: Dict[str, int] = field(default_factory=dict)
+    next_strength_perk: int = 5
+    next_intelligence_perk: int = 5
+    next_charisma_perk: int = 5
     inventory: List["InventoryItem"] = field(default_factory=list)
     equipment: Dict[str, Optional["InventoryItem"]] = field(
         default_factory=lambda: {

--- a/game.py
+++ b/game.py
@@ -15,6 +15,7 @@ from rendering import (
     draw_day_night,
     draw_ui,
     draw_inventory_screen,
+    draw_perk_menu,
 )
 from settings import (
     SCREEN_WIDTH,
@@ -74,15 +75,16 @@ QUESTS = [
 
 # Random events that may occur while exploring
 def _ev_found_money(p: Player) -> None:
-    p.money += 5
+    bonus = 5 * p.perk_levels.get("Lucky", 0)
+    p.money += 5 + bonus
 
 
 def _ev_gain_int(p: Player) -> None:
-    p.intelligence += 1
+    p.intelligence += 1 + p.perk_levels.get("Lucky", 0)
 
 
 def _ev_gain_cha(p: Player) -> None:
-    p.charisma += 1
+    p.charisma += 1 + p.perk_levels.get("Lucky", 0)
 
 
 def _ev_trip(p: Player) -> None:
@@ -139,6 +141,34 @@ SHOP_ITEMS = [
     ),
 ]
 
+# Upgrades available for purchase inside the home
+HOME_UPGRADES = [
+    ("Comfy Bed", 50, "Recover +20 energy when sleeping"),
+    ("Decorations", 40, "Gain +1 CHA each morning"),
+    ("Study Desk", 60, "Gain +1 INT each morning"),
+]
+
+# Perks that can be unlocked with perk points
+# Each perk can be upgraded up to PERK_MAX_LEVEL levels
+PERK_MAX_LEVEL = 3
+PERKS = [
+    ("Gym Rat", "STR training gives +1 per level"),
+    ("Book Worm", "INT studying gives +1 per level"),
+    ("Social Butterfly", "CHA chatting gives +1 per level"),
+    ("Night Owl", "Sleeping restores +10 energy per level"),
+    ("Lucky", "Random events yield extra rewards"),
+    ("Iron Will", "Energy costs reduced 5% per level"),
+]
+
+# Special hidden perks unlocked through achievements
+SECRET_PERKS = [
+    ("Bar Champion", "Win all 5 brawls"),
+    ("Home Owner", "Own every home upgrade"),
+    ("Perk Master", "Max out every other perk"),
+]
+
+BRAWLER_COUNT = 5
+
 def buy_shop_item(player: Player, index: int) -> str:
     """Attempt to buy an item from SHOP_ITEMS by index."""
     if index < 0 or index >= len(SHOP_ITEMS):
@@ -150,6 +180,20 @@ def buy_shop_item(player: Player, index: int) -> str:
         return "Not enough money!"
     player.money -= cost
     effect(player)
+    return f"Bought {name}"
+
+
+def buy_home_upgrade(player: Player, index: int) -> str:
+    """Attempt to purchase a home upgrade by index."""
+    if index < 0 or index >= len(HOME_UPGRADES):
+        return "Invalid upgrade"
+    name, cost, _ = HOME_UPGRADES[index]
+    if name in player.home_upgrades:
+        return "Already owned"
+    if player.money < cost:
+        return "Not enough money!"
+    player.money -= cost
+    player.home_upgrades.append(name)
     return f"Bought {name}"
 
 EVENT_CHANCE = 0.0008  # roughly once every ~20s at 60 FPS
@@ -174,6 +218,56 @@ def check_quests(player):
             q.completed = True
             new = True
     return new
+
+
+def check_perk_unlocks(player: Player) -> bool:
+    """Grant perk points when stat thresholds are reached."""
+    gained = False
+    if player.strength >= player.next_strength_perk:
+        player.perk_points += 1
+        player.next_strength_perk += 5
+        gained = True
+    if player.intelligence >= player.next_intelligence_perk:
+        player.perk_points += 1
+        player.next_intelligence_perk += 5
+        gained = True
+    if player.charisma >= player.next_charisma_perk:
+        player.perk_points += 1
+        player.next_charisma_perk += 5
+        gained = True
+    return gained
+
+
+def energy_cost(player: Player, base: float) -> float:
+    """Return energy cost adjusted by Iron Will and hidden perks."""
+    level = player.perk_levels.get("Iron Will", 0)
+    cost = base * (1 - 0.05 * level)
+    if player.perk_levels.get("Perk Master"):
+        cost *= 0.9
+    return cost
+
+
+def check_hidden_perks(player: Player) -> str | None:
+    """Unlock secret perks when requirements are met."""
+    if (
+        player.brawls_won >= BRAWLER_COUNT
+        and "Bar Champion" not in player.perk_levels
+    ):
+        player.perk_levels["Bar Champion"] = 1
+        return "Secret perk unlocked: Bar Champion!"
+    if (
+        set(player.home_upgrades) == {u[0] for u in HOME_UPGRADES}
+        and "Home Owner" not in player.perk_levels
+    ):
+        player.perk_levels["Home Owner"] = 1
+        return "Secret perk unlocked: Home Owner!"
+    if (
+        all(player.perk_levels.get(name, 0) >= PERK_MAX_LEVEL for name, _ in PERKS)
+        and "Perk Master" not in player.perk_levels
+    ):
+        player.perk_levels["Perk Master"] = 1
+        return "Secret perk unlocked: Perk Master!"
+    return None
 
 
 def random_event(player: Player) -> str | None:
@@ -220,6 +314,8 @@ def _combat_stats(player: Player):
     atk = player.strength
     df = player.defense
     spd = player.speed
+    if player.perk_levels.get("Bar Champion"):
+        atk += 2
     for item in player.equipment.values():
         if item:
             atk += item.attack
@@ -230,15 +326,18 @@ def _combat_stats(player: Player):
 
 
 def fight_brawler(player: Player) -> str:
+    if player.brawls_won >= BRAWLER_COUNT:
+        return "No challengers remain"
     if player.energy < 10:
         return "Too tired to fight!"
-    player.energy -= 10
+    player.energy -= energy_cost(player, 10)
 
+    stage = player.brawls_won + 1
     enemy = {
-        "attack": random.randint(3, 7),
-        "defense": random.randint(1, 4),
-        "speed": random.randint(1, 5),
-        "health": 20,
+        "attack": random.randint(3 + stage, 6 + stage * 2),
+        "defense": random.randint(1 + stage, 3 + stage),
+        "speed": random.randint(1 + stage // 2, 5 + stage // 2),
+        "health": 20 + stage * 10,
     }
     p_atk, p_def, p_spd = _combat_stats(player)
     p_hp = player.health
@@ -255,15 +354,13 @@ def fight_brawler(player: Player) -> str:
     player.health = max(p_hp, 0)
     if p_hp <= 0:
         return "You lost the fight!"
-    player.money += 20
-    return "You won the fight! +$20"
-
-    opponent = random.randint(1, 6)
-    if player.strength >= opponent:
-        player.money += 20
-        return "You won the fight! +$20"
-    player.health = max(player.health - 10, 0)
-    return "You lost the fight! -10 health"
+    reward = 20 + stage * 10
+    player.money += reward
+    player.brawls_won += 1
+    msg = f"You won the fight {stage}! +${reward}"
+    if player.brawls_won == BRAWLER_COUNT:
+        msg += " All brawlers defeated!"
+    return msg
 
 
 
@@ -289,7 +386,15 @@ def save_game(player):
         "clinic_shifts": player.clinic_shifts,
         "tokens": player.tokens,
 
+        "brawls_won": player.brawls_won,
+
         "has_skateboard": player.has_skateboard,
+        "home_upgrades": player.home_upgrades,
+        "perk_points": player.perk_points,
+        "perk_levels": player.perk_levels,
+        "next_strength_perk": player.next_strength_perk,
+        "next_intelligence_perk": player.next_intelligence_perk,
+        "next_charisma_perk": player.next_charisma_perk,
         "inventory": [item.__dict__ for item in player.inventory],
         "equipment": {
             slot: (it.__dict__ if it else None) for slot, it in player.equipment.items()
@@ -335,8 +440,15 @@ def load_game():
     player.clinic_level = data.get("clinic_level", player.clinic_level)
     player.clinic_shifts = data.get("clinic_shifts", player.clinic_shifts)
     player.tokens = data.get("tokens", player.tokens)
+    player.brawls_won = data.get("brawls_won", 0)
 
     player.has_skateboard = data.get("has_skateboard", player.has_skateboard)
+    player.home_upgrades = data.get("home_upgrades", [])
+    player.perk_points = data.get("perk_points", 0)
+    player.perk_levels = data.get("perk_levels", {})
+    player.next_strength_perk = data.get("next_strength_perk", 5)
+    player.next_intelligence_perk = data.get("next_intelligence_perk", 5)
+    player.next_charisma_perk = data.get("next_charisma_perk", 5)
     for item in data.get("inventory", []):
         player.inventory.append(InventoryItem(**item))
     for slot, item in data.get("equipment", {}).items():
@@ -377,6 +489,7 @@ def main():
     in_building = None
     frame = 0
     show_inventory = False
+    show_perk_menu = False
     dragging_item = None
     drag_origin = None
     drag_pos = (0, 0)
@@ -394,6 +507,13 @@ def main():
         if player.time >= 1440:
             player.time -= 1440
             player.day += 1
+        if check_perk_unlocks(player):
+            shop_message = "Gained a perk point! Press P to spend"
+            shop_message_timer = 90
+        secret = check_hidden_perks(player)
+        if secret:
+            shop_message = secret
+            shop_message_timer = 90
         item_rects = []
         if show_inventory:
             for i, item in enumerate(player.inventory):
@@ -421,6 +541,9 @@ def main():
                     shop_message_timer = 60
                 elif event.key == pygame.K_i:
                     show_inventory = not show_inventory
+                    dragging_item = None
+                elif event.key == pygame.K_p and player.perk_points > 0:
+                    show_perk_menu = not show_perk_menu
                     dragging_item = None
             if show_inventory:
                 if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
@@ -455,12 +578,29 @@ def main():
                     if not placed:
                         player.inventory.append(dragging_item)
                     dragging_item = None
+            if show_perk_menu and event.type == pygame.KEYDOWN:
+                if pygame.K_1 <= event.key <= pygame.K_9:
+                    idx = event.key - pygame.K_1
+                    if idx < len(PERKS):
+                        name = PERKS[idx][0]
+                        level = player.perk_levels.get(name, 0)
+                        if level < PERK_MAX_LEVEL and player.perk_points > 0:
+                            player.perk_levels[name] = level + 1
+                            player.perk_points -= 1
+                            shop_message = f"Perk upgraded: {name} Lv{level+1}"
+                            shop_message_timer = 90
+                        else:
+                            shop_message = "Perk at max level"
+                            shop_message_timer = 60
+                    show_perk_menu = False
+                elif event.key in (pygame.K_q, pygame.K_p):
+                    show_perk_menu = False
             if event.type == pygame.KEYDOWN and in_building:
                 if in_building == "job":
                     if player.energy >= 20:
                         pay = 30 + 20 * (player.office_level - 1)
                         player.money += pay
-                        player.energy -= 20
+                        player.energy -= energy_cost(player, 20)
                         player.office_shifts += 1
                         if (
                             player.office_shifts >= 10
@@ -478,11 +618,27 @@ def main():
                         shop_message = "Too tired to work!"
                     shop_message_timer = 60
                 elif in_building == "home":
-                    player.energy = 100
-                    player.time = 8 * 60
-                    player.day += 1
-                    shop_message = "You slept. New day!"
-                    shop_message_timer = 60
+                    if event.key == pygame.K_e:
+                        player.energy = 100
+                        if "Comfy Bed" in player.home_upgrades:
+                            player.energy += 20
+                        player.energy += 10 * player.perk_levels.get("Night Owl", 0)
+                        player.time = 8 * 60
+                        player.day += 1
+                        if "Decorations" in player.home_upgrades:
+                            player.charisma += 1
+                        if "Study Desk" in player.home_upgrades:
+                            player.intelligence += 1
+                        if player.perk_levels.get("Home Owner"):
+                            player.health = min(player.health + 10, 100)
+                        shop_message = "You slept. New day!"
+                        shop_message_timer = 60
+                    elif pygame.K_1 <= event.key <= pygame.K_9:
+                        idx = event.key - pygame.K_1
+                        shop_message = buy_home_upgrade(player, idx)
+                        shop_message_timer = 60
+                    else:
+                        continue
                 elif in_building == "shop":
                     if pygame.K_1 <= event.key <= pygame.K_9:
                         idx = event.key - pygame.K_1
@@ -499,10 +655,13 @@ def main():
                 elif in_building == "gym":
                     if player.money >= 10 and player.energy >= 10:
                         player.money -= 10
-                        player.energy -= 10
+                        player.energy -= energy_cost(player, 10)
                         player.health = min(player.health + 5, 100)
-                        player.strength += 1
-                        shop_message = "You worked out! +1 STR, +5 health"
+                        bonus = player.perk_levels.get("Gym Rat", 0)
+                        gain = 1 + bonus
+                        player.strength += gain
+                        msg_gain = f" +{gain} STR"
+                        shop_message = "You worked out!" + msg_gain + ", +5 health"
                     elif player.money < 10:
                         shop_message = "Need $10 to train"
                     else:
@@ -511,9 +670,12 @@ def main():
                 elif in_building == "library":
                     if player.money >= 5 and player.energy >= 5:
                         player.money -= 5
-                        player.energy -= 5
-                        player.intelligence += 1
-                        shop_message = "You studied! +1 INT"
+                        player.energy -= energy_cost(player, 5)
+                        bonus = player.perk_levels.get("Book Worm", 0)
+                        gain = 1 + bonus
+                        player.intelligence += gain
+                        msg_gain = f" +{gain} INT"
+                        shop_message = "You studied!" + msg_gain
                     elif player.money < 5:
                         shop_message = "Need $5 to study"
                     else:
@@ -521,9 +683,12 @@ def main():
                     shop_message_timer = 60
                 elif in_building == "park":
                     if player.energy >= 5:
-                        player.energy -= 5
-                        player.charisma += 1
-                        shop_message = "You socialized! +1 CHA"
+                        player.energy -= energy_cost(player, 5)
+                        bonus = player.perk_levels.get("Social Butterfly", 0)
+                        gain = 1 + bonus
+                        player.charisma += gain
+                        msg_gain = f" +{gain} CHA"
+                        shop_message = "You socialized!" + msg_gain
                     else:
                         shop_message = "Too tired to chat!"
                     shop_message_timer = 60
@@ -550,7 +715,7 @@ def main():
                     if player.energy >= 20:
                         pay = 50 + 25 * (player.dealer_level - 1)
                         player.money += pay
-                        player.energy -= 20
+                        player.energy -= energy_cost(player, 20)
                         player.dealer_shifts += 1
                         if (
                             player.dealer_shifts >= 10
@@ -569,7 +734,7 @@ def main():
                     if player.energy >= 20:
                         pay = 40 + 20 * (player.clinic_level - 1)
                         player.money += pay
-                        player.energy -= 20
+                        player.energy -= energy_cost(player, 20)
                         player.clinic_shifts += 1
                         if (
                             player.clinic_shifts >= 10
@@ -612,7 +777,7 @@ def main():
                     if dx != 0 or dy != 0:
                         if frame % 12 == 0:
                             step_sound.play()
-                        player.energy = max(player.energy - 0.04, 0)
+                        player.energy = max(player.energy - 0.04 * (1 - 0.05 * player.perk_levels.get("Iron Will", 0)), 0)
                     player.rect = next_rect
 
         near_building = None
@@ -674,6 +839,8 @@ def main():
                 item_rects,
                 (dragging_item, drag_pos) if dragging_item else None,
             )
+        if show_perk_menu:
+            draw_perk_menu(screen, font, player, PERKS)
 
         info_y = 46
         if near_building and not in_building:
@@ -688,7 +855,7 @@ def main():
                 pay = 40 + 20 * (player.clinic_level - 1)
                 msg = f"[E] to Work here (+${pay}, -20 energy)"
             elif near_building.btype == "home":
-                msg = "[E] to Sleep (restore energy, next day)"
+                msg = "[E] to enter home"
             elif near_building.btype == "shop":
                 msg = "[E] to shop for items"
             elif near_building.btype == "gym":
@@ -723,7 +890,7 @@ def main():
                 pay = 40 + 20 * (player.clinic_level - 1)
                 txt = f"[E] Work (+${pay})  [Q] Leave"
             elif in_building == "home":
-                txt = "[E] Sleep  [Q] Leave"
+                txt = "[E] Sleep  [1-3] Buy upgrade  [Q] Leave"
             elif in_building == "shop":
                 txt = "[0-9] Buy items  [Q] Leave"
             elif in_building == "gym":
@@ -742,6 +909,11 @@ def main():
                     row = i // 5
                     col = i % 5
                     screen.blit(item_surf, (30 + col * 150, SCREEN_HEIGHT - 60 - row * 24))
+            elif in_building == "home":
+                for i, (name, cost, _d) in enumerate(HOME_UPGRADES):
+                    status = "Owned" if name in player.home_upgrades else f"${cost}"
+                    item_surf = font.render(f"{i+1}:{name} {status}", True, (80, 40, 40))
+                    screen.blit(item_surf, (30 + i * 200, SCREEN_HEIGHT - 60))
 
         if shop_message_timer > 0:
             shop_message_timer -= 1

--- a/rendering.py
+++ b/rendering.py
@@ -25,6 +25,7 @@ from settings import (
     SCREEN_WIDTH,
 )
 
+PERK_MAX_LEVEL = 3
 PLAYER_SPRITES = []
 
 
@@ -212,4 +213,27 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
         bg_rect = bg.get_rect(center=pos)
         surface.blit(bg, bg_rect.topleft)
         surface.blit(txt, (bg_rect.x + 4, bg_rect.y + 20))
+
+
+def draw_perk_menu(surface, font, player, perks):
+    overlay = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 160))
+    surface.blit(overlay, (0, 0))
+
+    panel = pygame.Surface((SCREEN_WIDTH - 120, SCREEN_HEIGHT - 120))
+    panel.fill((240, 240, 220))
+    surface.blit(panel, (60, 60))
+
+    title = font.render("Choose a Perk", True, FONT_COLOR)
+    surface.blit(title, (SCREEN_WIDTH // 2 - title.get_width() // 2, 70))
+
+    for i, (name, desc) in enumerate(perks):
+        level = player.perk_levels.get(name, 0)
+        txt = font.render(
+            f"{i+1}: {name} Lv{level}/{PERK_MAX_LEVEL} - {desc}", True, FONT_COLOR
+        )
+        surface.blit(txt, (100, 120 + i * 40))
+
+    info = font.render(f"Points: {player.perk_points}   [Q] Exit", True, FONT_COLOR)
+    surface.blit(info, (100, 120 + len(perks) * 40 + 20))
 


### PR DESCRIPTION
## Summary
- add secret perks unlocked by special achievements
- implement sequential bar fights up to five opponents
- track brawls won and save/load this value
- unlock Bar Champion, Home Owner and Perk Master perks automatically
- update README with hidden perk details

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685a982f15cc8326bc3dcf9e107a7a3d