### PR TITLE
Fix missing BG_COLOR import

### DIFF
--- a/rendering.py
+++ b/rendering.py
@@ -25,6 +25,7 @@ from settings import (
     MAP_HEIGHT,
     SCREEN_WIDTH,
     SCREEN_HEIGHT,
+    BG_COLOR,
 )
 
 PERK_MAX_LEVEL = 3


### PR DESCRIPTION
## Summary
- import `BG_COLOR` in `rendering.py`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685be7428790832682c9d0e52bfc1ed9