### PR TITLE
Improve building graphics with subtle shadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ these locations. The world runs on a 24-hour clock with automatic day changes.
 Buildings keep regular hours and the city darkens at night.
 
 A colorful gradient sky and detailed buildings give the city a cleaner look.
+Buildings now cast subtle drop shadows for a little extra depth.
 When the game launches you are greeted with a small start menu allowing you to
 load a save or begin anew.
 

--- a/rendering.py
+++ b/rendering.py
@@ -33,6 +33,7 @@ from settings import (
     TREE_COLOR,
     TRUNK_COLOR,
     FLOWER_COLORS,
+    SHADOW_COLOR,
 )
 
 PERK_MAX_LEVEL = 3
@@ -141,6 +142,10 @@ def draw_building(surface, building, highlight=False):
     color = building_color(building.btype)
     if highlight:
         color = tuple(min(255, c + 40) for c in color)
+    # Draw a subtle drop shadow for depth
+    shadow = pygame.Surface((b.width, b.height), pygame.SRCALPHA)
+    pygame.draw.rect(shadow, SHADOW_COLOR, shadow.get_rect(), border_radius=9)
+    surface.blit(shadow, (b.x + 4, b.y + 4))
     pygame.draw.rect(surface, color, b, border_radius=9)
     if highlight:
         pygame.draw.rect(surface, (255, 255, 0), b, 2, border_radius=9)


### PR DESCRIPTION
## Summary
- import `SHADOW_COLOR` for new shading use
- add a drop shadow behind buildings to improve depth
- document the new visual touch in the README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6872578f98748326a0973684853cabaa