### PR TITLE
Add dynamic sun and moon overlay

### DIFF
--- a/game.py
+++ b/game.py
@@ -1416,7 +1416,7 @@ def main():
             cam_x = min(max(0, player.rect.centerx - settings.SCREEN_WIDTH // 2), MAP_WIDTH - settings.SCREEN_WIDTH)
             cam_y = min(max(0, player.rect.centery - settings.SCREEN_HEIGHT // 2), MAP_HEIGHT - settings.SCREEN_HEIGHT)
 
-        draw_sky(screen)
+        draw_sky(screen, player.time)
 
         draw_road_and_sidewalks(screen, cam_x, cam_y)
         draw_city_walls(screen, cam_x, cam_y)

--- a/rendering.py
+++ b/rendering.py
@@ -211,8 +211,8 @@ def draw_decorations(surface, cam_x, cam_y):
         _draw_flower_patch(surface, fx - cam_x, fy - cam_y)
 
 
-def draw_sky(surface):
-    """Draw a vertical gradient sky background."""
+def draw_sky(surface, current_time):
+    """Draw a vertical gradient sky background with a sun or moon."""
     top_color = (120, 180, 255)
     bottom_color = BG_COLOR
     for y in range(settings.SCREEN_HEIGHT):
@@ -221,6 +221,16 @@ def draw_sky(surface):
         g = int(top_color[1] * (1 - ratio) + bottom_color[1] * ratio)
         b = int(top_color[2] * (1 - ratio) + bottom_color[2] * ratio)
         pygame.draw.line(surface, (r, g, b), (0, y), (settings.SCREEN_WIDTH, y))
+
+    # add a simple sun or moon that moves across the sky
+    day_fraction = (current_time % (24 * 60)) / (24 * 60)
+    x = int(day_fraction * settings.SCREEN_WIDTH)
+    y = int(80 - 60 * math.cos(day_fraction * 2 * math.pi))
+    hour = int(current_time) // 60
+    if 6 <= hour < 18:
+        pygame.draw.circle(surface, (255, 240, 150), (x, y), 40)
+    else:
+        pygame.draw.circle(surface, (230, 230, 255), (x, y), 30)
 def draw_day_night(surface, current_time):
     """Darken the city during nighttime hours."""
     hour = int(current_time) // 60


### PR DESCRIPTION
## Summary
- give `draw_sky` access to game time and render a moving sun/moon
- pass the player's time to `draw_sky`

## Testing
- `python -m py_compile rendering.py game.py`
- `SDL_VIDEODRIVER=dummy python game.py` *(terminated with Ctrl+C after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68738976e4e883269cc401c0380782fa