### PR TITLE
Add mute and fullscreen toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ starts. Press **F1** at any time for a quick reminder of the controls.
 - **F5**: Save game
 - **F9**: Load game
 - **F1**: Toggle help screen
+- **F11**: Toggle fullscreen
+- **M**: Mute/unmute audio
 
 ## Requirements
 

--- a/game.py
+++ b/game.py
@@ -687,6 +687,8 @@ def main():
     drag_origin = None
     drag_pos = (0, 0)
     slot_rects = compute_slot_rects()
+    fullscreen = False
+    muted = False
 
     while True:
         frame += 1
@@ -749,6 +751,21 @@ def main():
                     dragging_item = None
                 elif event.key == pygame.K_F1:
                     show_help = True
+                elif event.key == pygame.K_F11:
+                    fullscreen = not fullscreen
+                    flags = pygame.FULLSCREEN if fullscreen else pygame.RESIZABLE
+                    screen = pygame.display.set_mode((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT), flags)
+                    recalc_layouts()
+                    slot_rects = compute_slot_rects()
+                elif event.key == pygame.K_m and SOUND_ENABLED:
+                    muted = not muted
+                    vol = 0 if muted else SFX_VOLUME
+                    if step_sound:
+                        for snd in (step_sound, enter_sound, quest_sound):
+                            snd.set_volume(vol)
+                        pygame.mixer.music.set_volume(0 if muted else MUSIC_VOLUME)
+                    shop_message = "Sound muted" if muted else "Sound on"
+                    shop_message_timer = 60
                 elif event.key == pygame.K_h and not show_inventory and not show_log and not in_building:
                     pot = next((i for i in player.inventory if i.name == "Health Potion"), None)
                     if pot:

--- a/rendering.py
+++ b/rendering.py
@@ -499,6 +499,7 @@ def draw_help_screen(surface, font):
         "Interact: E    Leave building: Q",
         "Inventory: I    Perks: P    Quest Log: L",
         "Save: F5    Load: F9    Toggle Help: F1",
+        "Fullscreen: F11    Mute Audio: M",
     ]
     y = 160
     for line in lines:


### PR DESCRIPTION
## Summary
- allow toggling fullscreen with F11
- allow muting/unmuting audio with M
- document the new controls in README and help screen

## Testing
- `python -m py_compile game.py rendering.py combat.py entities.py inventory.py quests.py settings.py`
- `python game.py` *(fails: XDG_RUNTIME_DIR errors but game starts)*

------
https://chatgpt.com/codex/tasks/task_e_687926ea670483268ca7c701241355de