### PR TITLE
Implement quest markers, abilities, and expanded crafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Win a brawl and you pocket some cash. Combat has been enhanced with a chance
 to dodge incoming hits based on your speed. You also have a small chance each
 turn to unleash a **power strike** that deals double damage and causes the
 opponent to bleed for a few turns.
+Two active abilities further spice up battles. Hit **Z** to ready a Heavy
+Strike that deals extra damage in your next fight, or **X** to assume a
+Guard Stance that halves incoming damage. Each ability has a short cooldown.
 
 The shop now stocks a few useful items: a cola to restore a little energy, a
 protein bar for health, a book that teaches you intelligence, a gym pass that
@@ -91,6 +94,8 @@ money or tokens.
 A new **Workshop** lets you craft and upgrade gear. Fights and events can
 yield metal, cloth, and herbs. Spend these resources to brew Health Potions,
 forge stronger weapons, or enhance your armor.
+You can also craft home decorations, brew Energy Potions, and forge a
+powerful Flaming Sword using extra resources.
 
 A small **Farm** south of town lets you grow crops. Buy seeds in the shop, plant
 them at the farm, and harvest them three days later for extra cash.
@@ -131,6 +136,8 @@ A short quest line walks you through the basics: earning money, training, and
 taking on thugs in the new Alley location. Press **L** at any time to open the
 quest log and review your progress. The current quest also appears under the
 stats bar.
+An arrow above your character now points toward the next objective so you
+always know where to go.
 
 Random encounters can also happen while walking around. These short events may
 reward or penalize you with money, stats, or health, adding some surprise to
@@ -168,7 +175,9 @@ starts. Press **F1** at any time for a quick reminder of the controls.
 - **0-9**: Buy items in the shop
 - **1-3**: Adopt a pet in the Pet Shop
 - **I**: Open inventory and equip gear
-- **H**: Drink a Health Potion
+- **H**: Drink a potion
+- **Z**: Heavy Strike ability
+- **X**: Guard Stance ability
 - **D** at the bar: Play darts
 - **F** at the park: Go fishing
 - **P** at the library: Solve puzzle

--- a/entities.py
+++ b/entities.py
@@ -88,6 +88,13 @@ class Player:
     # List of unlocked achievements
     achievements: List[str] = field(default_factory=list)
 
+    # Active combat ability primed for next fight
+    active_ability: Optional[str] = None
+    # Cooldown timers for abilities (in frames)
+    ability_cooldowns: Dict[str, int] = field(
+        default_factory=lambda: {"heavy": 0, "guard": 0}
+    )
+
 
 
 @dataclass

--- a/quests.py
+++ b/quests.py
@@ -30,6 +30,17 @@ QUESTS: List[Quest] = [
     ),
 ]
 
+# Building targets for quest markers
+QUEST_TARGETS = {
+    0: "job",
+    1: "gym",
+    2: "library",
+    3: "job",
+    4: "gym",
+    5: "dungeon",
+    6: "home",
+}
+
 # Optional side quests
 SIDE_QUEST = SideQuest(
     "Bank Delivery",
@@ -52,6 +63,9 @@ MALL_QUEST = SideQuest(
     lambda p: setattr(p, "money", p.money + 40),
 )
 
+# Lookup active side quests by name
+SIDE_QUESTS = {q.name: q for q in [SIDE_QUEST, NPC_QUEST, MALL_QUEST]}
+
 NPCS = [NPC(pygame.Rect(500, 500, 40, 40), "Sam", NPC_QUEST)]
 
 # Main storyline quests progressed via story_stage
@@ -61,6 +75,14 @@ STORY_QUESTS = [
     Quest("Prove your loyalty", lambda p: p.story_stage >= 3),
     Quest("Report back to your ally", lambda p: p.story_stage >= 4),
 ]
+
+# Suggested locations for story objectives
+STORY_TARGETS = {
+    0: "townhall",
+    1: "townhall",
+    2: "dungeon",
+    3: "townhall",
+}
 
 
 # Event helpers

--- a/rendering.py
+++ b/rendering.py
@@ -112,6 +112,21 @@ def draw_npc(surface, npc, font, offset=(0, 0)):
         surface.blit(msg_surf, (bx + 5, by + 3))
 
 
+def draw_quest_marker(surface, player_rect, target_rect, cam_x, cam_y):
+    """Draw an arrow above the player pointing toward the target."""
+    px = player_rect.centerx - cam_x
+    py = player_rect.centery - cam_y
+    tx = target_rect.centerx - cam_x
+    ty = target_rect.centery - cam_y
+    angle = math.atan2(ty - py, tx - px)
+    x = px
+    y = py - 40
+    tip = (x + 20 * math.cos(angle), y + 20 * math.sin(angle))
+    left = (x + 8 * math.cos(angle + math.pi * 0.75), y + 8 * math.sin(angle + math.pi * 0.75))
+    right = (x + 8 * math.cos(angle - math.pi * 0.75), y + 8 * math.sin(angle - math.pi * 0.75))
+    pygame.draw.polygon(surface, (255, 50, 50), [tip, left, right])
+
+
 def building_color(btype):
     if btype == "home":
         return HOME_COLOR
@@ -356,6 +371,13 @@ def draw_ui(surface, font, player, quests, story_quests=None):
     h_txt = font.render("H", True, FONT_COLOR)
     bar.blit(e_txt, (6, 42))
     bar.blit(h_txt, (130, 42))
+    cd_txt = font.render(
+        f"Z:{player.ability_cooldowns['heavy']//60 if player.ability_cooldowns['heavy'] else 'R'} "
+        f"X:{player.ability_cooldowns['guard']//60 if player.ability_cooldowns['guard'] else 'R'}",
+        True,
+        FONT_COLOR,
+    )
+    bar.blit(cd_txt, (settings.SCREEN_WIDTH - cd_txt.get_width() - 20, 32))
     surface.blit(bar, (0, 0))
 
     # Show current quest below the stat bar
@@ -500,6 +522,7 @@ def draw_help_screen(surface, font):
         "Inventory: I    Perks: P    Quest Log: L",
         "Save: F5    Load: F9    Toggle Help: F1",
         "Fullscreen: F11    Mute Audio: M",
+        "Abilities: Z Heavy  X Guard",
     ]
     y = 160
     for line in lines:


### PR DESCRIPTION
## Summary
- show quest direction arrows and quest target data
- add heavy strike and guard stance abilities with cooldowns
- expand workshop recipes for decorations, energy potions, and flaming sword
- track ability cooldowns on the Player
- update help screen, controls, and README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687a351fabc08326bd2a2e34cefa06b1