### PR TITLE
Add quick item hotkeys and combo weapons

### DIFF
--- a/combat.py
+++ b/combat.py
@@ -29,11 +29,12 @@ def energy_cost(player: Player, base: float) -> float:
     return cost
 
 
-def _combat_stats(player: Player) -> Tuple[int, int, int]:
-    """Return player's attack, defense and speed with equipment and perks."""
+def _combat_stats(player: Player) -> Tuple[int, int, int, int]:
+    """Return player's attack, defense, speed and combo with equipment."""
     atk = player.strength
     df = player.defense
     spd = player.speed
+    combo = 1
     if player.perk_levels.get("Bar Champion"):
         atk += 2
     if player.companion == "Dog":
@@ -43,7 +44,9 @@ def _combat_stats(player: Player) -> Tuple[int, int, int]:
             atk += item.attack
             df += item.defense
             spd += item.speed
-    return atk, df, spd
+            if item.slot == "weapon":
+                combo = getattr(item, "combo", 1)
+    return atk, df, spd, combo
 
 
 def fight_brawler(player: Player) -> str:
@@ -62,7 +65,7 @@ def fight_brawler(player: Player) -> str:
         "speed": random.randint(1 + stage // 2, 5 + stage // 2),
         "health": 20 + stage * 10,
     }
-    p_atk, p_def, p_spd = _combat_stats(player)
+    p_atk, p_def, p_spd, p_combo = _combat_stats(player)
     p_hp = player.health
     e_hp = enemy["health"]
     turn_player = p_spd >= enemy["speed"]
@@ -70,12 +73,15 @@ def fight_brawler(player: Player) -> str:
     bleed_turns = 0
     while p_hp > 0 and e_hp > 0:
         if turn_player:
-            dmg = max(1, p_atk - enemy["defense"])
-            if not special_used and random.random() < POWER_STRIKE_CHANCE:
-                dmg *= 2
-                bleed_turns = BLEED_TURNS
-                special_used = True
-            e_hp -= dmg
+            for _ in range(p_combo):
+                dmg = max(1, p_atk - enemy["defense"])
+                if (
+                    not special_used and random.random() < POWER_STRIKE_CHANCE
+                ):
+                    dmg *= 2
+                    bleed_turns = BLEED_TURNS
+                    special_used = True
+                e_hp -= dmg
         else:
             if random.random() < (DODGE_BASE + player.speed * 0.02):
                 pass
@@ -111,7 +117,7 @@ def fight_enemy(player: Player) -> str:
         "speed": random.randint(1, 4),
         "health": 15 + 5 * scale,
     }
-    p_atk, p_def, p_spd = _combat_stats(player)
+    p_atk, p_def, p_spd, p_combo = _combat_stats(player)
     p_hp = player.health
     e_hp = enemy["health"]
     turn_player = p_spd >= enemy["speed"]
@@ -119,12 +125,15 @@ def fight_enemy(player: Player) -> str:
     bleed_turns = 0
     while p_hp > 0 and e_hp > 0:
         if turn_player:
-            dmg = max(1, p_atk - enemy["defense"])
-            if not special_used and random.random() < POWER_STRIKE_CHANCE:
-                dmg *= 2
-                bleed_turns = BLEED_TURNS
-                special_used = True
-            e_hp -= dmg
+            for _ in range(p_combo):
+                dmg = max(1, p_atk - enemy["defense"])
+                if (
+                    not special_used and random.random() < POWER_STRIKE_CHANCE
+                ):
+                    dmg *= 2
+                    bleed_turns = BLEED_TURNS
+                    special_used = True
+                e_hp -= dmg
         else:
             if random.random() < (DODGE_BASE + player.speed * 0.02):
                 pass
@@ -165,7 +174,7 @@ def fight_forest_enemy(player: Player, index: int) -> str:
     player.energy -= energy_cost(player, 10)
 
     enemy = FOREST_ENEMIES[index]
-    p_atk, p_def, p_spd = _combat_stats(player)
+    p_atk, p_def, p_spd, p_combo = _combat_stats(player)
     p_hp = player.health
     e_hp = enemy["health"]
     turn_player = p_spd >= enemy["speed"]
@@ -173,12 +182,15 @@ def fight_forest_enemy(player: Player, index: int) -> str:
     bleed_turns = 0
     while p_hp > 0 and e_hp > 0:
         if turn_player:
-            dmg = max(1, p_atk - enemy["defense"])
-            if not special_used and random.random() < POWER_STRIKE_CHANCE:
-                dmg *= 2
-                bleed_turns = BLEED_TURNS
-                special_used = True
-            e_hp -= dmg
+            for _ in range(p_combo):
+                dmg = max(1, p_atk - enemy["defense"])
+                if (
+                    not special_used and random.random() < POWER_STRIKE_CHANCE
+                ):
+                    dmg *= 2
+                    bleed_turns = BLEED_TURNS
+                    special_used = True
+                e_hp -= dmg
         else:
             if random.random() < (DODGE_BASE + player.speed * 0.02):
                 pass

--- a/entities.py
+++ b/entities.py
@@ -95,6 +95,16 @@ class Player:
         default_factory=lambda: {"heavy": 0, "guard": 0}
     )
 
+    # Quick item hotkey slots
+    hotkeys: List[Optional["InventoryItem"]] = field(
+        default_factory=lambda: [None] * 5
+    )
+
+    # Furniture placed inside the home
+    furniture: Dict[str, Optional["InventoryItem"]] = field(
+        default_factory=lambda: {"slot1": None, "slot2": None, "slot3": None}
+    )
+
 
 
 @dataclass
@@ -139,5 +149,6 @@ class InventoryItem:
     attack: int = 0
     defense: int = 0
     speed: int = 0
+    combo: int = 1
     level: int = 0
 

--- a/inventory.py
+++ b/inventory.py
@@ -4,8 +4,12 @@ from entities import Player, InventoryItem
 
 # Items sold at the shop: name, cost, and effect
 SHOP_ITEMS: List[Tuple[str, int, any]] = [
-    ("Cola", 3, lambda p: setattr(p, "energy", min(100, p.energy + 5))),
-    ("Protein Bar", 7, lambda p: setattr(p, "health", min(100, p.health + 5))),
+    ("Cola", 3, lambda p: p.inventory.append(InventoryItem("Cola", "consumable"))),
+    (
+        "Protein Bar",
+        7,
+        lambda p: p.inventory.append(InventoryItem("Protein Bar", "consumable")),
+    ),
     ("Book", 10, lambda p: setattr(p, "intelligence", p.intelligence + 1)),
     ("Gym Pass", 15, lambda p: setattr(p, "strength", p.strength + 1)),
     ("Charm Pendant", 20, lambda p: setattr(p, "charisma", p.charisma + 1)),
@@ -17,7 +21,11 @@ SHOP_ITEMS: List[Tuple[str, int, any]] = [
     ("Leather Boots", 20, lambda p: p.inventory.append(
         InventoryItem("Leather Boots", "legs", defense=1, speed=1))),
     ("Wooden Sword", 35, lambda p: p.inventory.append(
-        InventoryItem("Wooden Sword", "weapon", attack=2))),
+        InventoryItem("Wooden Sword", "weapon", attack=2, combo=1))),
+    ("Spear", 55, lambda p: p.inventory.append(
+        InventoryItem("Spear", "weapon", attack=3, combo=2))),
+    ("Bow", 70, lambda p: p.inventory.append(
+        InventoryItem("Bow", "weapon", attack=2, speed=1, combo=2))),
     ("Seeds x3", 15, lambda p: p.resources.__setitem__(
         "seeds", p.resources.get("seeds", 0) + 3)),
 ]

--- a/rendering.py
+++ b/rendering.py
@@ -395,7 +395,7 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         surface.blit(qsurf, (22, bar_height + 6))
 
 
-def draw_inventory_screen(surface, font, player, slot_rects, item_rects, dragging):
+def draw_inventory_screen(surface, font, player, slot_rects, item_rects, dragging, hotkey_rects=None, furn_rects=None):
     overlay = pygame.Surface((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT), pygame.SRCALPHA)
     overlay.fill((0, 0, 0, 160))
     surface.blit(overlay, (0, 0))
@@ -414,7 +414,7 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
         item = player.equipment.get(slot)
         if item:
             it = font.render(
-                f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed}",
+                f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed} C{item.combo}",
                 True,
                 FONT_COLOR,
             )
@@ -423,7 +423,7 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
     for rect, item in item_rects:
         pygame.draw.rect(surface, (200, 220, 230), rect)
         txt = font.render(
-            f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed}",
+            f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed} C{item.combo}",
             True,
             FONT_COLOR,
         )
@@ -432,7 +432,7 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
     if dragging:
         item, pos = dragging
         txt = font.render(
-            f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed}",
+            f"{item.name} Lv{item.level} A{item.attack} D{item.defense} S{item.speed} C{item.combo}",
             True,
             FONT_COLOR,
         )
@@ -445,6 +445,27 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
     res = f"Metal:{player.resources.get('metal',0)} Cloth:{player.resources.get('cloth',0)} Herbs:{player.resources.get('herbs',0)}"
     res_txt = font.render(res, True, FONT_COLOR)
     surface.blit(res_txt, (100, settings.SCREEN_HEIGHT - 120))
+
+    if hotkey_rects:
+        for i, rect in enumerate(hotkey_rects):
+            pygame.draw.rect(surface, (210, 210, 210), rect)
+            label = font.render(str(i + 1), True, FONT_COLOR)
+            surface.blit(label, (rect.x + 2, rect.y - 20))
+            item = player.hotkeys[i]
+            if item:
+                txt = font.render(item.name, True, FONT_COLOR)
+                surface.blit(txt, (rect.x + 4, rect.y + 14))
+
+    if furn_rects:
+        for idx, rect in enumerate(furn_rects):
+            pygame.draw.rect(surface, (200, 190, 150), rect)
+            label = font.render(f"F{idx+1}", True, FONT_COLOR)
+            surface.blit(label, (rect.x + 2, rect.y - 20))
+            slot = f"slot{idx+1}"
+            item = player.furniture.get(slot)
+            if item:
+                txt = font.render(item.name, True, FONT_COLOR)
+                surface.blit(txt, (rect.x + 4, rect.y + 20))
 
 
 def draw_perk_menu(surface, font, player, perks):
@@ -544,7 +565,18 @@ def draw_tip_panel(surface, font, text):
     surface.blit(tip_surf, (20, settings.SCREEN_HEIGHT - 80))
 
 
-def draw_home_interior(surface, font, player, frame, bed_rect, door_rect):
+def draw_hotkey_bar(surface, font, player, rects):
+    for i, rect in enumerate(rects):
+        pygame.draw.rect(surface, (210, 210, 210), rect)
+        label = font.render(str(i + 1), True, FONT_COLOR)
+        surface.blit(label, (rect.x + 2, rect.y - 18))
+        item = player.hotkeys[i]
+        if item:
+            txt = font.render(item.name, True, FONT_COLOR)
+            surface.blit(txt, (rect.x + 4, rect.y + 10))
+
+
+def draw_home_interior(surface, font, player, frame, bed_rect, door_rect, furn_rects):
     """Draw a simple interior of the player's home."""
     surface.fill((235, 225, 200))
     # walls
@@ -560,6 +592,14 @@ def draw_home_interior(surface, font, player, frame, bed_rect, door_rect):
     # door
     pygame.draw.rect(surface, (100, 80, 60), door_rect)
     pygame.draw.circle(surface, (220, 210, 120), (door_rect.right - 20, door_rect.centery), 6)
+
+    for idx, rect in enumerate(furn_rects):
+        pygame.draw.rect(surface, (200, 190, 150), rect)
+        slot = f"slot{idx+1}"
+        item = player.furniture.get(slot)
+        if item:
+            txt = font.render(item.name, True, FONT_COLOR)
+            surface.blit(txt, (rect.x + 4, rect.y + 20))
 
     draw_player_sprite(surface, player.rect, frame, player.facing_left)
 


### PR DESCRIPTION
## Summary
- add new `hotkeys` and `furniture` fields on `Player`
- support weapon combo stat on `InventoryItem`
- implement quick‐access hotkey bar UI
- allow dragging consumables and furniture items
- add new weapons (spear and bow) with combo values
- enable simple home decorations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a4173c40883269c6ee58208744bd6