### PR TITLE
Add collectible trading cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ reward or penalize you with money, stats, or health, adding some surprise to
 each day. Certain encounters only appear at specific times such as early
 morning joggers or late-night food stands.
 
+A new set of ten trading cards can also be discovered at random. Keep exploring
+to complete your collection!
+
 You can save your progress with **F5** and load it back with **F9**. If a
 `savegame.json` file exists, it will automatically be loaded when the game
 starts. Press **F1** at any time for a quick reminder of the controls.

--- a/entities.py
+++ b/entities.py
@@ -89,6 +89,9 @@ class Player:
     # List of unlocked achievements
     achievements: List[str] = field(default_factory=list)
 
+    # Collection of discovered trading cards
+    cards: List[str] = field(default_factory=list)
+
     # Active combat ability primed for next fight
     active_ability: Optional[str] = None
     # Cooldown timers for abilities (in frames)

--- a/game.py
+++ b/game.py
@@ -590,6 +590,7 @@ def save_game(player):
         "season": player.season,
         "weather": player.weather,
         "achievements": player.achievements,
+        "cards": player.cards,
     }
     with open(SAVE_FILE, "w") as f:
         json.dump(data, f)
@@ -654,6 +655,7 @@ def load_game():
     player.season = data.get("season", "Spring")
     player.weather = data.get("weather", "Clear")
     player.achievements = data.get("achievements", [])
+    player.cards = data.get("cards", [])
     for item in data.get("inventory", []):
         player.inventory.append(InventoryItem(**item))
     for slot, item in data.get("equipment", {}).items():

--- a/quests.py
+++ b/quests.py
@@ -11,6 +11,20 @@ from entities import Player, Quest, Event, SideQuest, NPC
 from inventory import HOME_UPGRADES
 from combat import BRAWLER_COUNT
 
+# Names of collectible trading cards
+CARD_NAMES = [
+    "Slime",
+    "Goblin",
+    "Knight",
+    "Dragon",
+    "Merchant",
+    "Wizard",
+    "Farmer",
+    "Pirate",
+    "Robot",
+    "Alien",
+]
+
 # Storyline quests completed in order
 QUESTS: List[Quest] = [
     Quest("Earn $200", lambda p: p.money >= 200),
@@ -146,6 +160,13 @@ def _ev_found_herb(p: Player) -> None:
     p.resources["herbs"] = p.resources.get("herbs", 0) + 1
 
 
+def _ev_found_card(p: Player) -> None:
+    """Grant a random trading card that hasn't been collected yet."""
+    remaining = [c for c in CARD_NAMES if c not in p.cards]
+    if remaining:
+        p.cards.append(random.choice(remaining))
+
+
 EVENTS = [
     Event("You found $5 on the ground!", _ev_found_money),
     Event("Someone shared a study tip. +1 INT", _ev_gain_int),
@@ -158,6 +179,7 @@ EVENTS = [
     Event("Picked up some scrap metal", _ev_found_metal),
     Event("Found a piece of cloth", _ev_found_cloth),
     Event("Gathered herbs nearby", _ev_found_herb),
+    Event("You found a trading card!", _ev_found_card),
 ]
 
 SEASON_EVENTS = {

--- a/rendering.py
+++ b/rendering.py
@@ -357,6 +357,12 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         FONT_COLOR,
     )
     bar.blit(res_txt, (16, 20))
+    card_stat = font.render(
+        f"Cards: {len(player.cards)}/10",
+        True,
+        FONT_COLOR,
+    )
+    bar.blit(card_stat, (settings.SCREEN_WIDTH - card_stat.get_width() - 20, 20))
     season_txt = font.render(f"{player.season} - {player.weather}", True, FONT_COLOR)
     bar.blit(season_txt, (settings.SCREEN_WIDTH // 2 - season_txt.get_width() // 2, 32))
     if player.companion:
@@ -445,6 +451,11 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
     res = f"Metal:{player.resources.get('metal',0)} Cloth:{player.resources.get('cloth',0)} Herbs:{player.resources.get('herbs',0)}"
     res_txt = font.render(res, True, FONT_COLOR)
     surface.blit(res_txt, (100, settings.SCREEN_HEIGHT - 120))
+    card_line = ", ".join(player.cards) if player.cards else "None"
+    card_txt = font.render(
+        f"Cards ({len(player.cards)}/10): {card_line}", True, FONT_COLOR
+    )
+    surface.blit(card_txt, (100, settings.SCREEN_HEIGHT - 100))
 
     if hotkey_rects:
         for i, rect in enumerate(hotkey_rects):


### PR DESCRIPTION
## Summary
- introduce a list of collectible trading cards
- grant random cards as new random events
- track collected cards in save files
- display card progress in the UI and inventory
- mention cards in documentation

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce35c05a88326849ceed515edd238