### PR TITLE
Improve job careers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ side quest. Accept the job, bring the papers to the Library, and earn $50.
 You can also deposit or withdraw cash at the bank. Any money left in the bank
 earns 1% interest each day.
 
-Jobs now offer promotions based on your stats. The office rewards
+Jobs now offer promotions based on your stats and the experience you build.
+The office rewards
 intelligence and charisma while dealing drugs in the park relies on strength
 and charisma. A new clinic job values intelligence and strength. Higher stats
 increase your job level and the pay you receive. The park offers a riskier
 "drug dealer" job at night that pays more but depends on strength and
 charisma.
+Working jobs now grants experience toward promotions. Each job has unique
+titles such as Intern or Nurse and awards a small stat bonus when you level
+up. Progress and experience are shown in the HUD so you always know how close
+you are to the next promotion.
 
 A new bar sells $10 tokens that can be used to play blackjack or the slots.
 Win games to earn extra tokens, or lose them if luck is not on your side.

--- a/careers.py
+++ b/careers.py
@@ -1,0 +1,116 @@
+"""Career system handling job titles and promotions."""
+
+from typing import Dict, List
+from entities import Player
+from combat import energy_cost
+
+# Career progression data
+JOB_DATA: Dict[str, Dict] = {
+    "office": {
+        "titles": ["Intern", "Clerk", "Manager", "Director", "Executive"],
+        "level_attr": "office_level",
+        "shift_attr": "office_shifts",
+        "exp_attr": "office_exp",
+        "stats": ["intelligence", "charisma"],
+        "base_pay": 20,
+        "pay_step": 15,
+        "exp_per_shift": 10,
+        "exp_base": 100,
+        "bonus": "intelligence",
+    },
+    "dealer": {
+        "titles": ["Lookout", "Runner", "Dealer", "Supplier", "Kingpin"],
+        "level_attr": "dealer_level",
+        "shift_attr": "dealer_shifts",
+        "exp_attr": "dealer_exp",
+        "stats": ["strength", "charisma"],
+        "base_pay": 40,
+        "pay_step": 20,
+        "exp_per_shift": 10,
+        "exp_base": 100,
+        "bonus": "charisma",
+    },
+    "clinic": {
+        "titles": ["Assistant", "Nurse", "Doctor", "Surgeon", "Chief"],
+        "level_attr": "clinic_level",
+        "shift_attr": "clinic_shifts",
+        "exp_attr": "clinic_exp",
+        "stats": ["intelligence", "strength"],
+        "base_pay": 30,
+        "pay_step": 15,
+        "exp_per_shift": 10,
+        "exp_base": 100,
+        "bonus": "strength",
+    },
+}
+
+
+def get_job_title(player: Player, job_key: str) -> str:
+    """Return the player's title for the given job."""
+    data = JOB_DATA[job_key]
+    level = getattr(player, data["level_attr"])
+    titles: List[str] = data["titles"]
+    return titles[level - 1] if level - 1 < len(titles) else f"Lv{level}"
+
+
+def job_exp_needed(player: Player, job_key: str) -> int:
+    """Return the experience required for the next promotion."""
+    data = JOB_DATA[job_key]
+    level = getattr(player, data["level_attr"])
+    return data["exp_base"] * level
+
+
+def job_progress(player: Player, job_key: str) -> tuple[int, int]:
+    """Return current experience and required amount for the next level."""
+    data = JOB_DATA[job_key]
+    exp = getattr(player, data["exp_attr"])
+    level = getattr(player, data["level_attr"])
+    if level >= len(data["titles"]):
+        need = 0
+    else:
+        need = job_exp_needed(player, job_key)
+    return exp, need
+
+
+def work_job(player: Player, job_key: str) -> str:
+    """Handle working a shift and possible promotion."""
+    data = JOB_DATA[job_key]
+    if player.energy < 20:
+        return "Too tired to work!"
+
+    level_attr = data["level_attr"]
+    shift_attr = data["shift_attr"]
+    exp_attr = data["exp_attr"]
+    level = getattr(player, level_attr)
+
+    pay = data["base_pay"] + data["pay_step"] * (level - 1)
+    player.money += pay
+    player.energy -= energy_cost(player, 20)
+    setattr(player, shift_attr, getattr(player, shift_attr) + 1)
+    exp = getattr(player, exp_attr) + data["exp_per_shift"]
+    setattr(player, exp_attr, exp)
+
+    req1 = getattr(player, data["stats"][0])
+    req2 = getattr(player, data["stats"][1])
+    need_exp = job_exp_needed(player, job_key)
+    max_level = level >= len(data["titles"])
+
+    if not max_level and exp >= need_exp and req1 >= 5 * level and req2 >= 5 * level:
+        setattr(player, level_attr, level + 1)
+        setattr(player, shift_attr, 0)
+        setattr(player, exp_attr, exp - need_exp)
+        bonus = data.get("bonus")
+        if bonus:
+            setattr(player, bonus, getattr(player, bonus) + 1)
+        new_title = get_job_title(player, job_key)
+        return f"Promoted to {new_title}!"
+
+    title = get_job_title(player, job_key)
+    return f"Worked as {title}! +${pay}, +{data['exp_per_shift']}xp"
+
+def job_pay(player: Player, job_key: str) -> int:
+    """Return the current pay for the job based on level."""
+    data = JOB_DATA[job_key]
+    level = getattr(player, data["level_attr"])
+    return data["base_pay"] + data["pay_step"] * (level - 1)
+

--- a/entities.py
+++ b/entities.py
@@ -28,6 +28,9 @@ class Player:
     dealer_shifts: int = 0
     clinic_level: int = 1
     clinic_shifts: int = 0
+    office_exp: int = 0
+    dealer_exp: int = 0
+    clinic_exp: int = 0
     tokens: int = 0
     has_skateboard: bool = False
     facing_left: bool = False

--- a/game.py
+++ b/game.py
@@ -91,6 +91,7 @@ from quests import (
     STORY_TARGETS,
     SIDE_QUESTS,
 )
+from careers import work_job, get_job_title, job_pay
 import settings
 from settings import (
     MAP_WIDTH,
@@ -554,6 +555,9 @@ def save_game(player):
         "dealer_shifts": player.dealer_shifts,
         "clinic_level": player.clinic_level,
         "clinic_shifts": player.clinic_shifts,
+        "office_exp": player.office_exp,
+        "dealer_exp": player.dealer_exp,
+        "clinic_exp": player.clinic_exp,
         "tokens": player.tokens,
 
         "brawls_won": player.brawls_won,
@@ -630,10 +634,13 @@ def load_game():
 
     player.office_level = data.get("office_level", player.office_level)
     player.office_shifts = data.get("office_shifts", player.office_shifts)
+    player.office_exp = data.get("office_exp", 0)
     player.dealer_level = data.get("dealer_level", player.dealer_level)
     player.dealer_shifts = data.get("dealer_shifts", player.dealer_shifts)
+    player.dealer_exp = data.get("dealer_exp", 0)
     player.clinic_level = data.get("clinic_level", player.clinic_level)
     player.clinic_shifts = data.get("clinic_shifts", player.clinic_shifts)
+    player.clinic_exp = data.get("clinic_exp", 0)
     player.tokens = data.get("tokens", player.tokens)
     player.brawls_won = data.get("brawls_won", 0)
     player.enemies_defeated = data.get("enemies_defeated", 0)
@@ -1091,25 +1098,7 @@ def main():
 
             if event.type == pygame.KEYDOWN and in_building:
                 if in_building == "job" and event.key == pygame.K_e:
-                    if player.energy >= 20:
-                        pay = 20 + 15 * (player.office_level - 1)
-                        player.money += pay
-                        player.energy -= energy_cost(player, 20)
-                        player.office_shifts += 1
-                        if (
-                            player.office_shifts >= 10
-                            and player.intelligence >= 5 * player.office_level
-                            and player.charisma >= 5 * player.office_level
-                        ):
-                            player.office_level += 1
-                            player.office_shifts = 0
-                            shop_message = (
-                                f"You were promoted! Office level {player.office_level}"
-                            )
-                        else:
-                            shop_message = f"You worked! +${pay}, -20 energy"
-                    else:
-                        shop_message = "Too tired to work!"
+                    shop_message = work_job(player, "office")
                     shop_message_timer = 60
                 elif in_building == "home":
                     player.energy = 100
@@ -1390,42 +1379,10 @@ def main():
                         continue
                     shop_message_timer = 90
                 elif in_building == "dealer" and event.key == pygame.K_e:
-                    if player.energy >= 20:
-                        pay = 40 + 20 * (player.dealer_level - 1)
-                        player.money += pay
-                        player.energy -= energy_cost(player, 20)
-                        player.dealer_shifts += 1
-                        if (
-                            player.dealer_shifts >= 10
-                            and player.strength >= 5 * player.dealer_level
-                            and player.charisma >= 5 * player.dealer_level
-                        ):
-                            player.dealer_level += 1
-                            player.dealer_shifts = 0
-                            shop_message = f"You were promoted! Dealer level {player.dealer_level}"
-                        else:
-                            shop_message = f"You dealt! +${pay}, -20 energy"
-                    else:
-                        shop_message = "Too tired to deal!"
+                    shop_message = work_job(player, "dealer")
                     shop_message_timer = 60
                 elif in_building == "clinic" and event.key == pygame.K_e:
-                    if player.energy >= 20:
-                        pay = 30 + 15 * (player.clinic_level - 1)
-                        player.money += pay
-                        player.energy -= energy_cost(player, 20)
-                        player.clinic_shifts += 1
-                        if (
-                            player.clinic_shifts >= 10
-                            and player.intelligence >= 5 * player.clinic_level
-                            and player.strength >= 5 * player.clinic_level
-                        ):
-                            player.clinic_level += 1
-                            player.clinic_shifts = 0
-                            shop_message = f"You were promoted! Clinic level {player.clinic_level}"
-                        else:
-                            shop_message = f"You treated patients! +${pay}, -20 energy"
-                    else:
-                        shop_message = "Too tired to work here!"
+                    shop_message = work_job(player, "clinic")
                     shop_message_timer = 60
 
         dx = dy = 0
@@ -1723,13 +1680,13 @@ def main():
         if near_building and not in_building:
             msg = ""
             if near_building.btype == "job":
-                pay = 20 + 15 * (player.office_level - 1)
+                pay = job_pay(player, "office")
                 msg = f"[E] to Work here (+${pay}, -20 energy)"
             elif near_building.btype == "dealer":
-                pay = 40 + 20 * (player.dealer_level - 1)
+                pay = job_pay(player, "dealer")
                 msg = f"[E] to Deal drugs (+${pay}, -20 energy)"
             elif near_building.btype == "clinic":
-                pay = 30 + 15 * (player.clinic_level - 1)
+                pay = job_pay(player, "clinic")
                 msg = f"[E] to Work here (+${pay}, -20 energy)"
             elif near_building.btype == "home":
                 msg = "[E] to enter home"
@@ -1779,13 +1736,13 @@ def main():
         if in_building:
             txt = ""
             if in_building == "job":
-                pay = 20 + 15 * (player.office_level - 1)
+                pay = job_pay(player, "office")
                 txt = f"[E] Work (+${pay})  [Q] Leave"
             elif in_building == "dealer":
-                pay = 40 + 20 * (player.dealer_level - 1)
+                pay = job_pay(player, "dealer")
                 txt = f"[E] Deal (+${pay})  [Q] Leave"
             elif in_building == "clinic":
-                pay = 30 + 15 * (player.clinic_level - 1)
+                pay = job_pay(player, "clinic")
                 txt = f"[E] Work (+${pay})  [Q] Leave"
             elif in_building == "home":
                 txt = "[E] Sleep  [1-9] Buy upgrade  [Q] Leave"

--- a/rendering.py
+++ b/rendering.py
@@ -36,6 +36,7 @@ from settings import (
     FLOWER_COLORS,
     SHADOW_COLOR,
 )
+from careers import get_job_title, job_progress
 
 PERK_MAX_LEVEL = 3
 PLAYER_SPRITES = []
@@ -342,11 +343,21 @@ def draw_ui(surface, font, player, quests, story_quests=None):
     hour = int(player.time) // 60
     minute = int(player.time) % 60
     time_str = f"{hour:02d}:{minute:02d}"
+    o_exp, o_need = job_progress(player, "office")
+    d_exp, d_need = job_progress(player, "dealer")
+    c_exp, c_need = job_progress(player, "clinic")
+    office_prog = f"{o_exp}/{o_need}" if o_need else "MAX"
+    dealer_prog = f"{d_exp}/{d_need}" if d_need else "MAX"
+    clinic_prog = f"{c_exp}/{c_need}" if c_need else "MAX"
+    job_info = (
+        f"Office:{get_job_title(player, 'office')} L{player.office_level}({office_prog})  "
+        f"Dealer:{get_job_title(player, 'dealer')} L{player.dealer_level}({dealer_prog})  "
+        f"Clinic:{get_job_title(player, 'clinic')} L{player.clinic_level}({clinic_prog})"
+    )
     text = font.render(
         f"Money: ${int(player.money)}  Tokens: {player.tokens}  Energy: {int(player.energy)}  Health: {int(player.health)}  "
         f"STR:{player.strength} DEF:{player.defense} SPD:{player.speed} INT:{player.intelligence} CHA:{player.charisma}  "
-
-        f"Office Lv: {player.office_level}  Dealer Lv: {player.dealer_level}  Clinic Lv: {player.clinic_level}  Day: {player.day}  Time: {time_str}",
+        f"{job_info}  Day: {player.day}  Time: {time_str}",
         True,
         FONT_COLOR,
     )


### PR DESCRIPTION
## Summary
- add job experience fields to `Player` and persist them
- expand `careers` module with experience and stat bonuses
- display job experience progress in the HUD
- document the deeper career system in the README

## Testing
- `python -m py_compile careers.py rendering.py game.py entities.py inventory.py combat.py quests.py`


------
https://chatgpt.com/codex/tasks/task_e_687cf5e3093483268c98d62ae18fba8a