### PR TITLE
Add epithet system

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ the secret **Perk Master** perk.
 An achievement system tracks milestones like your first victory, amassing
 $1000, and finishing the main quest line. Clearing the story records your
 completion day and money in a local leaderboard shown on the title screen.
+Achievements now also grant flavorful epithets such as *the Slayer* which
+appear beside your stats.
 
 A shady **Alley** building lets you battle random enemies for cash and the
 occasional token. Victories count toward quest progress and scale in difficulty

--- a/entities.py
+++ b/entities.py
@@ -97,6 +97,9 @@ class Player:
     # Collection of discovered trading cards
     cards: List[str] = field(default_factory=list)
 
+    # Current honorific title earned through achievements
+    epithet: str = ""
+
     # Active combat ability primed for next fight
     active_ability: Optional[str] = None
     # Cooldown timers for abilities (in frames)

--- a/game.py
+++ b/game.py
@@ -623,6 +623,7 @@ def save_game(player):
         "weather": player.weather,
         "achievements": player.achievements,
         "cards": player.cards,
+        "epithet": player.epithet,
     }
     with open(SAVE_FILE, "w") as f:
         json.dump(data, f)
@@ -692,6 +693,7 @@ def load_game():
     player.weather = data.get("weather", "Clear")
     player.achievements = data.get("achievements", [])
     player.cards = data.get("cards", [])
+    player.epithet = data.get("epithet", "")
     for item in data.get("inventory", []):
         player.inventory.append(InventoryItem(**item))
     for slot, item in data.get("equipment", {}).items():

--- a/quests.py
+++ b/quests.py
@@ -11,6 +11,15 @@ from entities import Player, Quest, Event, SideQuest, NPC
 from inventory import HOME_UPGRADES
 from combat import BRAWLER_COUNT
 
+# Epithets awarded for certain achievements
+ACHIEVEMENT_EPITHETS = {
+    "First Blood": "the Rookie",
+    "Brawler Master": "the Brawler",
+    "Wealthy": "the Rich",
+    "Story Hero": "the Hero",
+    "Boss Slayer": "the Slayer",
+}
+
 # Names of collectible trading cards
 CARD_NAMES = [
     "Slime",
@@ -403,15 +412,18 @@ def check_achievements(player: Player) -> str | None:
         and player.enemies_defeated >= 1
     ):
         player.achievements.append("First Blood")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("First Blood", player.epithet)
         return "Achievement unlocked: First Blood!"
     if (
         "Brawler Master" not in player.achievements
         and player.brawls_won >= BRAWLER_COUNT
     ):
         player.achievements.append("Brawler Master")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Brawler Master", player.epithet)
         return "Achievement unlocked: Brawler Master!"
     if "Wealthy" not in player.achievements and player.money >= 1000:
         player.achievements.append("Wealthy")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Wealthy", player.epithet)
         return "Achievement unlocked: Wealthy!"
     if (
         "Story Hero" not in player.achievements
@@ -419,8 +431,10 @@ def check_achievements(player: Player) -> str | None:
     ):
         player.achievements.append("Story Hero")
         update_leaderboard(player)
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Story Hero", player.epithet)
         return "Achievement unlocked: Story Hero!"
     if "Boss Slayer" not in player.achievements and player.boss_defeated:
         player.achievements.append("Boss Slayer")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Boss Slayer", player.epithet)
         return "Achievement unlocked: Boss Slayer!"
     return None

--- a/rendering.py
+++ b/rendering.py
@@ -362,6 +362,9 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         FONT_COLOR,
     )
     bar.blit(text, (16, 6))
+    if player.epithet:
+        ep_txt = font.render(player.epithet, True, FONT_COLOR)
+        bar.blit(ep_txt, (settings.SCREEN_WIDTH // 2 - ep_txt.get_width() // 2, 6))
     res_txt = font.render(
         f"M:{player.resources.get('metal',0)} C:{player.resources.get('cloth',0)} H:{player.resources.get('herbs',0)} S:{player.resources.get('seeds',0)}",
         True,


### PR DESCRIPTION
## Summary
- store a new `epithet` field on the player
- save/load epithet to `savegame.json`
- grant epithets when achievements unlock
- show the epithet in the UI
- document the new system in the README

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_687e4399fe008326a84da4334e7d9408