### PR TITLE
Add head color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Buildings now cast subtle drop shadows for a little extra depth.
 Soft white clouds drift across the sky to add more life to the background.
 When the game launches you are greeted with a small start menu allowing you to
 load a save or begin anew.
+Before entering the city you can also choose a name and pick both a body and head color.
 
 The city now includes a **Bank** where you can pick up a small delivery
 side quest. Accept the job, bring the papers to the Library, and earn $50.

--- a/entities.py
+++ b/entities.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Callable, List, Dict, Optional, Tuple
 import pygame
+import settings
 
 @dataclass
 class Building:
@@ -11,6 +12,9 @@ class Building:
 @dataclass
 class Player:
     rect: pygame.Rect
+    name: str = "Player"
+    color: Tuple[int, int, int] = settings.PLAYER_COLOR
+    head_color: Tuple[int, int, int] = settings.PLAYER_HEAD_COLOR
     money: float = 50
     energy: float = 100
     health: float = 100


### PR DESCRIPTION
## Summary
- add option to select a head color during character creation
- store the chosen head color in the player data
- tint player sprites using a faster overlay method

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687e41ae36a8832695f890e66f06bf51