### PR TITLE
Add produce farming and crafting integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ You can also craft home decorations, brew Energy Potions, and forge a
 powerful Flaming Sword using extra resources.
 
 A small **Farm** south of town lets you grow crops. Buy seeds in the shop, plant
-them at the farm, and harvest them three days later for extra cash.
+them at the farm, harvest them three days later, then sell the produce or use it
+in crafting recipes.
 
 The city map now stretches further east with three new areas. The **Suburbs**
 contain friendly neighbors who sometimes need a hand, the bustling **Mall**
@@ -215,6 +216,7 @@ starts. Press **F1** at any time for a quick reminder of the controls.
 - **P** at the library: Solve puzzle
 - **P** at the farm: Plant seed
 - **H** at the farm: Harvest crops
+- **S** at the farm: Sell produce
 - **H** in the Clinic: Heal for $20
 - **Shift**: Ride skateboard (if owned)
 - **T**: Skip 3 in-game hours

--- a/entities.py
+++ b/entities.py
@@ -85,7 +85,13 @@ class Player:
 
     # Crafting resources
     resources: Dict[str, int] = field(
-        default_factory=lambda: {"metal": 0, "cloth": 0, "herbs": 0, "seeds": 0}
+        default_factory=lambda: {
+            "metal": 0,
+            "cloth": 0,
+            "herbs": 0,
+            "seeds": 0,
+            "produce": 0,
+        }
     )
 
     # Days when seeds were planted on the farm

--- a/game.py
+++ b/game.py
@@ -50,6 +50,7 @@ from inventory import (
     train_companion,
     plant_seed,
     harvest_crops,
+    sell_produce,
 )
 from combat import (
     energy_cost,
@@ -698,7 +699,8 @@ def load_game():
     player.story_branch = data.get("story_branch")
     player.gang_package_done = data.get("gang_package_done", False)
     player.resources = data.get(
-        "resources", {"metal": 0, "cloth": 0, "herbs": 0, "seeds": 0}
+        "resources",
+        {"metal": 0, "cloth": 0, "herbs": 0, "seeds": 0, "produce": 0},
     )
     player.crops = data.get("crops", [])
     player.season = data.get("season", "Spring")
@@ -1026,6 +1028,9 @@ def main():
                         elif item.name in ("Protein Bar", "Health Potion"):
                             gain = 30 if item.name == "Health Potion" else 5
                             player.health = min(100, player.health + gain)
+                        elif item.name == "Fruit Pie":
+                            player.energy = min(100, player.energy + 10)
+                            player.health = min(100, player.health + 10)
                         player.hotkeys[idx] = None
                         shop_message = f"Used {item.name}"
                     else:
@@ -1426,6 +1431,13 @@ def main():
                             shop_message = "Forged Flaming Sword"
                         else:
                             shop_message = "Need 5 metal & 2 herbs"
+                    elif event.key == pygame.K_8:
+                        if player.resources.get("produce", 0) >= 2:
+                            player.resources["produce"] -= 2
+                            player.inventory.append(InventoryItem("Fruit Pie", "consumable"))
+                            shop_message = "Baked Fruit Pie"
+                        else:
+                            shop_message = "Need 2 produce"
                     else:
                         continue
                     shop_message_timer = 60
@@ -1434,6 +1446,8 @@ def main():
                         shop_message = plant_seed(player)
                     elif event.key == pygame.K_h:
                         shop_message = harvest_crops(player)
+                    elif event.key == pygame.K_s:
+                        shop_message = sell_produce(player)
                     else:
                         continue
                     shop_message_timer = 60
@@ -1924,7 +1938,7 @@ def main():
             elif in_building == "workshop":
                 txt = "1 Potion 2 Sword 3 Up Wpn 4 Up Arm  [Q] Leave"
             elif in_building == "farm":
-                txt = "[P] Plant seed  [H] Harvest  [Q] Leave"
+                txt = "[P] Plant seed  [H] Harvest  S:Sell  [Q] Leave"
             elif in_building == "mall":
                 txt = "[E] Pick up order  [Q] Leave"
             elif in_building == "beach":
@@ -1958,12 +1972,13 @@ def main():
                     "5:Decorations (1 metal,2 cloth)",
                     "6:Energy Potion (3 herbs)",
                     "7:Flaming Sword (5 metal,2 herbs)",
+                    "8:Fruit Pie (2 produce)",
                 ]
                 for i, txt_opt in enumerate(opts):
                     item_surf = font.render(txt_opt, True, (80, 40, 40))
                     screen.blit(item_surf, (30 + i * 300, settings.SCREEN_HEIGHT - 60))
             elif in_building == "farm":
-                opts = ["P:Plant (-1 seed)", "H:Harvest (ready crops)"]
+                opts = ["P:Plant (-1 seed)", "H:Harvest", "S:Sell produce"]
                 for i, txt_opt in enumerate(opts):
                     item_surf = font.render(txt_opt, True, (80, 40, 40))
                     screen.blit(item_surf, (30 + i * 260, settings.SCREEN_HEIGHT - 60))

--- a/inventory.py
+++ b/inventory.py
@@ -153,11 +153,22 @@ def harvest_crops(player: Player) -> str:
         return "Nothing ready"
     for d in ready:
         player.crops.remove(d)
-        gain = 15
-        if player.companion == "Llama":
-            gain += 5 * player.companion_level
-        player.money += gain
-    return f"Harvested {len(ready)} crops"
+        player.resources["produce"] = player.resources.get("produce", 0) + 1
+    return f"Harvested {len(ready)} produce"
+
+
+def sell_produce(player: Player) -> str:
+    """Sell all harvested produce for cash."""
+    count = player.resources.get("produce", 0)
+    if count <= 0:
+        return "No produce"
+    bonus = 0
+    if player.companion == "Llama":
+        bonus = 5 * player.companion_level
+    gain = (15 + bonus) * count
+    player.money += gain
+    player.resources["produce"] = 0
+    return f"Sold {count} produce"
 
 
 def train_companion(player: Player) -> str:

--- a/rendering.py
+++ b/rendering.py
@@ -381,7 +381,7 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         ep_txt = font.render(player.epithet, True, FONT_COLOR)
         bar.blit(ep_txt, (settings.SCREEN_WIDTH // 2 - ep_txt.get_width() // 2, 6))
     res_txt = font.render(
-        f"M:{player.resources.get('metal',0)} C:{player.resources.get('cloth',0)} H:{player.resources.get('herbs',0)} S:{player.resources.get('seeds',0)}",
+        f"M:{player.resources.get('metal',0)} C:{player.resources.get('cloth',0)} H:{player.resources.get('herbs',0)} S:{player.resources.get('seeds',0)} P:{player.resources.get('produce',0)}",
         True,
         FONT_COLOR,
     )
@@ -479,7 +479,12 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
         surface.blit(bg, bg_rect.topleft)
         surface.blit(txt, (bg_rect.x + 4, bg_rect.y + 20))
 
-    res = f"Metal:{player.resources.get('metal',0)} Cloth:{player.resources.get('cloth',0)} Herbs:{player.resources.get('herbs',0)}"
+    res = (
+        f"Metal:{player.resources.get('metal',0)} "
+        f"Cloth:{player.resources.get('cloth',0)} "
+        f"Herbs:{player.resources.get('herbs',0)} "
+        f"Produce:{player.resources.get('produce',0)}"
+    )
     res_txt = font.render(res, True, FONT_COLOR)
     surface.blit(res_txt, (100, settings.SCREEN_HEIGHT - 120))
     card_line = ", ".join(player.cards) if player.cards else "None"


### PR DESCRIPTION
## Summary
- allow Player resources to include `produce`
- harvest crops into produce and add option to sell it for cash
- craft fruit pies at the workshop using produce
- update hotkeys so fruit pie restores health and energy
- display produce in HUD and inventory screens
- document new farm workflow and controls

## Testing
- `python -m py_compile game.py inventory.py rendering.py entities.py`

------
https://chatgpt.com/codex/tasks/task_e_687e468b660c832692a6e0f6ca6d7dc1