### PR TITLE
Add crafting skill system

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ yield metal, cloth, and herbs. Spend these resources to brew Health Potions,
 forge stronger weapons, or enhance your armor.
 You can also craft home decorations, brew Energy Potions, and forge a
 powerful Flaming Sword using extra resources.
+Successful crafting now grants **crafting XP**. Gaining levels unlocks
+advanced recipes like Energy Potions and the Flaming Sword.
 
 A small **Farm** south of town lets you grow crops. Buy seeds in the shop, plant
 them at the farm, harvest them three days later, then sell the produce or use it

--- a/entities.py
+++ b/entities.py
@@ -36,6 +36,8 @@ class Player:
     dealer_exp: int = 0
     clinic_exp: int = 0
     tokens: int = 0
+    crafting_level: int = 1
+    crafting_exp: int = 0
     has_skateboard: bool = False
     facing_left: bool = False
     inventory: List["InventoryItem"] = field(default_factory=list)

--- a/game.py
+++ b/game.py
@@ -51,6 +51,8 @@ from inventory import (
     plant_seed,
     harvest_crops,
     sell_produce,
+    crafting_exp_needed,
+    gain_crafting_exp,
 )
 from combat import (
     energy_cost,
@@ -810,6 +812,9 @@ def main():
                                 InventoryItem("Health Potion", "consumable")
                             )
                             shop_message = "Crafted Health Potion"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 2 herbs"
                     elif event.key == pygame.K_2:
@@ -823,6 +828,9 @@ def main():
                                 )
                             )
                             shop_message = "Forged Iron Sword"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 3 metal"
                     elif event.key == pygame.K_3:
@@ -832,6 +840,9 @@ def main():
                             weapon.attack += 1
                             weapon.level += 1
                             shop_message = "Upgraded weapon"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need weapon & 2 metal"
                     elif event.key == pygame.K_4:
@@ -841,10 +852,15 @@ def main():
                             armor.defense += 1
                             armor.level += 1
                             shop_message = "Upgraded armor"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need armor & 2 cloth"
                     elif event.key == pygame.K_5:
-                        if player.resources.get("metal", 0) >= 1 and player.resources.get("cloth", 0) >= 2:
+                        if player.crafting_level < 2:
+                            shop_message = "Need Craft Lv2"
+                        elif player.resources.get("metal", 0) >= 1 and player.resources.get("cloth", 0) >= 2:
                             player.resources["metal"] -= 1
                             player.resources["cloth"] -= 2
                             if "Decorations" not in player.home_upgrades:
@@ -853,28 +869,46 @@ def main():
                             else:
                                 player.inventory.append(InventoryItem("Decor Chair", "furniture"))
                                 shop_message = "Crafted Decor Chair"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 1 metal & 2 cloth"
                     elif event.key == pygame.K_6:
-                        if player.resources.get("herbs", 0) >= 3:
+                        if player.crafting_level < 2:
+                            shop_message = "Need Craft Lv2"
+                        elif player.resources.get("herbs", 0) >= 3:
                             player.resources["herbs"] -= 3
                             player.inventory.append(InventoryItem("Energy Potion", "consumable"))
                             shop_message = "Brewed Energy Potion"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 3 herbs"
                     elif event.key == pygame.K_7:
-                        if player.resources.get("metal", 0) >= 5 and player.resources.get("herbs", 0) >= 2:
+                        if player.crafting_level < 3:
+                            shop_message = "Need Craft Lv3"
+                        elif player.resources.get("metal", 0) >= 5 and player.resources.get("herbs", 0) >= 2:
                             player.resources["metal"] -= 5
                             player.resources["herbs"] -= 2
                             player.inventory.append(InventoryItem("Flaming Sword", "weapon", attack=6))
                             shop_message = "Forged Flaming Sword"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 5 metal & 2 herbs"
                     elif event.key == pygame.K_8:
-                        if player.resources.get("produce", 0) >= 2:
+                        if player.crafting_level < 3:
+                            shop_message = "Need Craft Lv3"
+                        elif player.resources.get("produce", 0) >= 2:
                             player.resources["produce"] -= 2
                             player.inventory.append(InventoryItem("Fruit Pie", "consumable"))
                             shop_message = "Baked Fruit Pie"
+                            lvl_msg = gain_crafting_exp(player)
+                            if lvl_msg:
+                                shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 2 produce"
                     else:
@@ -1404,16 +1438,18 @@ def main():
                     screen.blit(item_surf, (30 + i * 200, settings.SCREEN_HEIGHT - 60))
             elif in_building == "workshop":
                 opts = [
-                    "1:Health Potion (2 herbs)",
-                    "2:Iron Sword (3 metal)",
-                    "3:Upgrade Weapon (2 metal)",
-                    "4:Upgrade Armor (2 cloth)",
-                    "5:Decorations (1 metal,2 cloth)",
-                    "6:Energy Potion (3 herbs)",
-                    "7:Flaming Sword (5 metal,2 herbs)",
-                    "8:Fruit Pie (2 produce)",
+                    ("1:Health Potion (2 herbs)", 1),
+                    ("2:Iron Sword (3 metal)", 1),
+                    ("3:Upgrade Weapon (2 metal)", 1),
+                    ("4:Upgrade Armor (2 cloth)", 1),
+                    ("5:Decorations (1 metal,2 cloth)", 2),
+                    ("6:Energy Potion (3 herbs)", 2),
+                    ("7:Flaming Sword (5 metal,2 herbs)", 3),
+                    ("8:Fruit Pie (2 produce)", 3),
                 ]
-                for i, txt_opt in enumerate(opts):
+                for i, (txt_opt, req) in enumerate(opts):
+                    if player.crafting_level < req:
+                        txt_opt += f" [Lv{req}]"
                     item_surf = font.render(txt_opt, True, (80, 40, 40))
                     screen.blit(item_surf, (30 + i * 300, settings.SCREEN_HEIGHT - 60))
             elif in_building == "farm":

--- a/helpers.py
+++ b/helpers.py
@@ -365,6 +365,8 @@ def save_game(player: Player) -> None:
         "dealer_exp": player.dealer_exp,
         "clinic_exp": player.clinic_exp,
         "tokens": player.tokens,
+        "crafting_level": player.crafting_level,
+        "crafting_exp": player.crafting_exp,
         "brawls_won": player.brawls_won,
         "enemies_defeated": player.enemies_defeated,
         "boss_defeated": player.boss_defeated,
@@ -437,6 +439,8 @@ def load_game() -> Optional[Player]:
     player.clinic_shifts = data.get("clinic_shifts", player.clinic_shifts)
     player.clinic_exp = data.get("clinic_exp", 0)
     player.tokens = data.get("tokens", player.tokens)
+    player.crafting_level = data.get("crafting_level", 1)
+    player.crafting_exp = data.get("crafting_exp", 0)
     player.brawls_won = data.get("brawls_won", 0)
     player.enemies_defeated = data.get("enemies_defeated", 0)
     player.boss_defeated = data.get("boss_defeated", False)

--- a/inventory.py
+++ b/inventory.py
@@ -198,3 +198,22 @@ def train_companion(player: Player) -> str:
     elif player.companion == "Rhino":
         player.strength += 1
     return f"{player.companion} reached level {player.companion_level}!"
+
+
+CRAFT_EXP_BASE = 50
+
+
+def crafting_exp_needed(player: Player) -> int:
+    """Experience required for next crafting level."""
+    return CRAFT_EXP_BASE * player.crafting_level
+
+
+def gain_crafting_exp(player: Player, amount: int = 5) -> str:
+    """Add crafting XP and handle level ups."""
+    player.crafting_exp += amount
+    msg = ""
+    while player.crafting_exp >= crafting_exp_needed(player):
+        player.crafting_exp -= crafting_exp_needed(player)
+        player.crafting_level += 1
+        msg = f"Crafting leveled to {player.crafting_level}!"
+    return msg

--- a/rendering.py
+++ b/rendering.py
@@ -37,6 +37,7 @@ from settings import (
     SHADOW_COLOR,
 )
 from careers import get_job_title, job_progress
+from inventory import crafting_exp_needed
 
 PERK_MAX_LEVEL = 3
 PLAYER_SPRITES = []
@@ -381,7 +382,7 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         ep_txt = font.render(player.epithet, True, FONT_COLOR)
         bar.blit(ep_txt, (settings.SCREEN_WIDTH // 2 - ep_txt.get_width() // 2, 6))
     res_txt = font.render(
-        f"M:{player.resources.get('metal',0)} C:{player.resources.get('cloth',0)} H:{player.resources.get('herbs',0)} S:{player.resources.get('seeds',0)} P:{player.resources.get('produce',0)}",
+        f"M:{player.resources.get('metal',0)} C:{player.resources.get('cloth',0)} H:{player.resources.get('herbs',0)} S:{player.resources.get('seeds',0)} P:{player.resources.get('produce',0)} Craft:{player.crafting_level}",
         True,
         FONT_COLOR,
     )
@@ -394,6 +395,9 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         FONT_COLOR,
     )
     bar.blit(card_stat, (settings.SCREEN_WIDTH - card_stat.get_width() - 20, 20))
+    craft_prog = f"{player.crafting_exp}/{crafting_exp_needed(player)}"
+    craft_txt = font.render(f"Craft XP: {craft_prog}", True, FONT_COLOR)
+    bar.blit(craft_txt, (settings.SCREEN_WIDTH - craft_txt.get_width() - 20, 32))
     season_txt = font.render(f"{player.season} - {player.weather}", True, FONT_COLOR)
     bar.blit(season_txt, (settings.SCREEN_WIDTH // 2 - season_txt.get_width() // 2, 32))
     if player.companion:


### PR DESCRIPTION
## Summary
- add crafting_level and crafting_exp on Player
- award crafting XP in workshop actions with level gating for advanced recipes
- save/load crafting skill data
- display crafting level/XP in the UI
- document new crafting XP mechanic in README

## Testing
- `python -m py_compile game.py entities.py inventory.py helpers.py rendering.py careers.py quests.py combat.py menus.py settings.py`


------
https://chatgpt.com/codex/tasks/task_e_6880ce3761888326b72961e33220496c