### PR TITLE
Add magic and ranged combat

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Basic equipment pieces like a leather helmet, leather armor, and boots can be
 purchased and equipped through the inventory screen. A wooden sword is also
 available for the weapon slot. Each item lists its attack (A), defense (D) and
 speed (S) bonuses.
+New Magic Wands and Crossbows let you specialize as a mage or ranger. Wands scale with Intelligence while bows and crossbows use your Speed for damage.
 Prices have been raised across the board and jobs pay a bit less, so it takes
 time to afford the best gear and home upgrades.
 

--- a/combat.py
+++ b/combat.py
@@ -40,7 +40,16 @@ def energy_cost(player: Player, base: float) -> float:
 
 def _combat_stats(player: Player) -> Tuple[int, int, int, int]:
     """Return player's attack, defense, speed and combo with equipment."""
-    atk = player.strength
+    weapon = player.equipment.get("weapon")
+    base_atk = player.strength
+    if weapon:
+        wtype = getattr(weapon, "weapon_type", "melee")
+        if wtype == "ranged":
+            base_atk = player.speed
+        elif wtype == "magic":
+            base_atk = player.intelligence
+
+    atk = base_atk
     df = player.defense
     spd = player.speed
     combo = 1

--- a/entities.py
+++ b/entities.py
@@ -187,4 +187,6 @@ class InventoryItem:
     speed: int = 0
     combo: int = 1
     level: int = 0
+    # melee, ranged or magic for weapons
+    weapon_type: str = "melee"
 

--- a/inventory.py
+++ b/inventory.py
@@ -26,7 +26,11 @@ SHOP_ITEMS: List[Tuple[str, int, any]] = [
     ("Spear", 55, lambda p: p.inventory.append(
         InventoryItem("Spear", "weapon", attack=3, combo=2))),
     ("Bow", 70, lambda p: p.inventory.append(
-        InventoryItem("Bow", "weapon", attack=2, speed=1, combo=2))),
+        InventoryItem("Bow", "weapon", attack=2, speed=1, combo=2, weapon_type="ranged"))),
+    ("Magic Wand", 80, lambda p: p.inventory.append(
+        InventoryItem("Magic Wand", "weapon", attack=3, speed=1, combo=1, weapon_type="magic"))),
+    ("Crossbow", 90, lambda p: p.inventory.append(
+        InventoryItem("Crossbow", "weapon", attack=4, combo=2, weapon_type="ranged"))),
     ("Seeds x3", 15, lambda p: p.resources.__setitem__(
         "seeds", p.resources.get("seeds", 0) + 3)),
 ]


### PR DESCRIPTION
## Summary
- add `weapon_type` to `InventoryItem`
- support ranged and magic scaling in `_combat_stats`
- extend shop inventory with wands and crossbows
- document new combat options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880d421e86c832693087b3d43922843