### PR TITLE
Add player-owned businesses with daily profits

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ A small **Farm** south of town lets you grow crops. Buy seeds in the shop, plant
 them at the farm, harvest them three days later, then sell the produce or use it
 in crafting recipes.
 
+Entrepreneurs can now purchase their own **Stall** or **Store** in the market.
+Press **1** or **2** inside the Stall to buy a business. Each day your
+charisma adds to its profits, and you can press **E** to play a short management
+minigame for extra earnings.
+
 The city map now stretches further east with three new areas. The **Suburbs**
 contain friendly neighbors who sometimes need a hand, the bustling **Mall**
 offers a short delivery side quest, and a sunny **Beach** lets you relax. You

--- a/businesses.py
+++ b/businesses.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from typing import List, Tuple
+import random
+
+from entities import Player
+from combat import energy_cost
+
+# (name, cost, base daily profit)
+BUSINESSES: List[Tuple[str, int, int]] = [
+    ("Stall", 500, 25),
+    ("Store", 2000, 80),
+]
+
+
+def buy_business(player: Player, index: int) -> str:
+    """Purchase a new business by index."""
+    if index < 0 or index >= len(BUSINESSES):
+        return "Invalid choice"
+    name, cost, profit = BUSINESSES[index]
+    if name in player.businesses:
+        return "Already owned"
+    if player.money < cost:
+        return "Not enough money!"
+    player.money -= cost
+    player.businesses[name] = profit
+    player.business_bonus[name] = 0
+    return f"Bought {name}"
+
+
+def manage_business(player: Player, name: str) -> str:
+    """Simple management minigame to boost profits."""
+    if name not in player.businesses:
+        return "No such business"
+    if player.energy < 5:
+        return "Too tired"
+    player.energy -= energy_cost(player, 5)
+    chance = player.charisma + random.randint(0, 10)
+    if chance > 10:
+        bonus = random.randint(10, 30)
+        player.business_bonus[name] = player.business_bonus.get(name, 0) + bonus
+        return f"Great promotion! +${bonus}"
+    return "Slow day at the shop"
+
+
+def collect_profits(player: Player) -> int:
+    """Return and add profits from all owned businesses."""
+    total = 0
+    for name, base in player.businesses.items():
+        bonus = player.business_bonus.get(name, 0)
+        profit = base + player.charisma * 2 + bonus
+        total += profit
+        player.business_bonus[name] = 0
+    player.money += total
+    return total

--- a/entities.py
+++ b/entities.py
@@ -77,6 +77,11 @@ class Player:
     # 1=apartment, 2=house, 3=mansion
     home_level: int = 1
 
+    # Player owned businesses with base profits
+    businesses: Dict[str, int] = field(default_factory=dict)
+    # Temporary profit bonuses earned from management
+    business_bonus: Dict[str, int] = field(default_factory=dict)
+
     # Tracks per-NPC interaction states
     npc_progress: Dict[str, int] = field(default_factory=dict)
 

--- a/game.py
+++ b/game.py
@@ -54,6 +54,7 @@ from inventory import (
     crafting_exp_needed,
     gain_crafting_exp,
 )
+from businesses import BUSINESSES, buy_business, manage_business
 from combat import (
     energy_cost,
     fight_brawler,
@@ -185,6 +186,7 @@ BUILDINGS = [
     Building(pygame.Rect(1800, 350, 240, 180), "Mall", "mall"),
     Building(pygame.Rect(2100, 150, 300, 200), "Suburbs", "suburbs"),
     Building(pygame.Rect(2400, 900, 260, 140), "Beach", "beach"),
+    Building(pygame.Rect(1900, 800, 220, 120), "Stall", "business"),
     Building(pygame.Rect(2900, 500, 220, 160), "Tower", "boss"),
 ]
 
@@ -924,6 +926,19 @@ def main():
                     else:
                         continue
                     shop_message_timer = 60
+                elif in_building == "business":
+                    if event.key == pygame.K_e:
+                        if player.businesses:
+                            name = next(iter(player.businesses))
+                            shop_message = manage_business(player, name)
+                        else:
+                            shop_message = "Press 1-2 to buy a business"
+                    elif pygame.K_1 <= event.key <= pygame.K_9:
+                        idx = event.key - pygame.K_1
+                        shop_message = buy_business(player, idx)
+                    else:
+                        continue
+                    shop_message_timer = 60
                 elif in_building == "mall" and event.key == pygame.K_e:
                     if not player.side_quest:
                         player.side_quest = MALL_QUEST.name
@@ -1354,6 +1369,8 @@ def main():
                 msg = "[E] to craft gear"
             elif near_building.btype == "farm":
                 msg = "[E] to manage crops"
+            elif near_building.btype == "business":
+                msg = "[E] manage or 1-2 buy"
             elif near_building.btype == "mall":
                 msg = "[E] to browse the mall"
             elif near_building.btype == "beach":
@@ -1412,6 +1429,12 @@ def main():
                 txt = "1 Potion 2 Sword 3 Up Wpn 4 Up Arm  [Q] Leave"
             elif in_building == "farm":
                 txt = "[P] Plant seed  [H] Harvest  S:Sell  [Q] Leave"
+            elif in_building == "business":
+                opts = []
+                for i, (name, cost, _p) in enumerate(BUSINESSES):
+                    status = "Owned" if name in player.businesses else f"${cost}"
+                    opts.append(f"{i+1}:{name} {status}")
+                txt = " ".join(opts) + "  E:Manage  [Q] Leave"
             elif in_building == "mall":
                 txt = "[E] Pick up order  [Q] Leave"
             elif in_building == "beach":

--- a/helpers.py
+++ b/helpers.py
@@ -20,6 +20,7 @@ from quests import (
     QUEST_TARGETS,
 )
 from combat import energy_cost
+from businesses import collect_profits
 import settings
 
 
@@ -159,6 +160,7 @@ OPEN_HOURS = {
     "workshop": (8, 20),
     "farm": (6, 20),
     "forest": (0, 24),
+    "business": (8, 18),
     "mall": (10, 21),
     "suburbs": (0, 24),
     "beach": (6, 20),
@@ -240,6 +242,9 @@ def sleep(player: Player) -> Optional[str]:
     if "Arcade Room" in player.home_upgrades and random.random() < 0.3:
         player.tokens += 1
         messages.append("Won a token in your arcade")
+    profits = collect_profits(player)
+    if profits:
+        messages.append(f"Your businesses earned ${profits}")
     if interest:
         messages.append(f"Earned ${interest} interest")
     return " ".join(messages) if messages else None
@@ -381,6 +386,8 @@ def save_game(player: Player) -> None:
         "next_strength_perk": player.next_strength_perk,
         "next_intelligence_perk": player.next_intelligence_perk,
         "next_charisma_perk": player.next_charisma_perk,
+        "businesses": player.businesses,
+        "business_bonus": player.business_bonus,
         "current_quest": player.current_quest,
         "enemies_defeated": player.enemies_defeated,
         "inventory": [item.__dict__ for item in player.inventory],
@@ -447,6 +454,8 @@ def load_game() -> Optional[Player]:
     player.has_skateboard = data.get("has_skateboard", player.has_skateboard)
     player.home_upgrades = data.get("home_upgrades", [])
     player.home_level = data.get("home_level", 1)
+    player.businesses = data.get("businesses", {})
+    player.business_bonus = data.get("business_bonus", {})
     player.bank_balance = data.get("bank_balance", 0.0)
     player.perk_points = data.get("perk_points", 0)
     player.perk_levels = data.get("perk_levels", {})


### PR DESCRIPTION
## Summary
- add businesses module with purchase and management mini-game
- track owned businesses in `Player`
- earn profits each day when sleeping
- add Stall building to map and controls for running businesses
- document businesses in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880dad1896c8326a0d2873777cce80f