### PR TITLE
Centralize PERK_MAX_LEVEL constant

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants used across modules."""
+
+# Maximum perk upgrade level
+PERK_MAX_LEVEL = 3

--- a/game.py
+++ b/game.py
@@ -96,6 +96,7 @@ from quests import (
     SIDE_QUESTS,
 )
 from careers import work_job, get_job_title, job_pay
+from constants import PERK_MAX_LEVEL
 import settings
 from settings import (
     MAP_WIDTH,
@@ -255,7 +256,6 @@ def _ev_found_cloth(p: Player) -> None:
 
 # Perks that can be unlocked with perk points
 # Each perk can be upgraded up to PERK_MAX_LEVEL levels
-PERK_MAX_LEVEL = 3
 PERKS = [
     ("Gym Rat", "STR training gives +1 per level"),
     ("Book Worm", "INT studying gives +1 per level"),

--- a/rendering.py
+++ b/rendering.py
@@ -38,8 +38,8 @@ from settings import (
 )
 from careers import get_job_title, job_progress
 from inventory import crafting_exp_needed
+from constants import PERK_MAX_LEVEL
 
-PERK_MAX_LEVEL = 3
 PLAYER_SPRITES = []
 PLAYER_SPRITE_COLOR = None
 FOREST_ENEMY_IMAGES = []


### PR DESCRIPTION
## Summary
- introduce `constants.py` to share common constants
- remove duplicate `PERK_MAX_LEVEL` definitions
- reference the constant from `game.py` and `rendering.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688101b37d248326913cea1e1b987abe