### PR TITLE
Add trading card duel minigame

### DIFF
--- a/cardgame.py
+++ b/cardgame.py
@@ -1,0 +1,47 @@
+"""Simple trading card duel mini-game."""
+
+from __future__ import annotations
+import random
+from typing import List
+
+from entities import Player
+from quests import CARD_NAMES
+
+# Extra rare cards that can only be obtained from duels
+RARE_CARDS: List[str] = ["Phoenix", "Golem"]
+
+
+def _card_power(name: str) -> int:
+    """Return a basic power score for a card name."""
+    if name in CARD_NAMES:
+        return CARD_NAMES.index(name) + 1
+    if name in RARE_CARDS:
+        return len(CARD_NAMES) + RARE_CARDS.index(name) + 2
+    return 1
+
+
+def card_duel(player: Player) -> str:
+    """Duel an NPC using random cards."""
+    if player.energy < 5:
+        return "Too tired to duel!"
+    player.energy -= 5
+
+    npc_cards = random.sample(CARD_NAMES, k=3)
+    deck = player.cards if player.cards else CARD_NAMES
+    player_cards = random.sample(deck, k=3)
+
+    player_score = sum(_card_power(c) for c in player_cards)
+    npc_score = sum(_card_power(c) for c in npc_cards)
+
+    if player_score >= npc_score:
+        player.card_duels_won += 1
+        pool = [c for c in CARD_NAMES if c not in player.cards]
+        if not pool and random.random() < 0.3:
+            pool = [c for c in RARE_CARDS if c not in player.cards]
+        if pool:
+            reward = random.choice(pool)
+            player.cards.append(reward)
+            return f"You won the duel and got {reward}!"
+        return "You won the duel!"
+
+    return "You lost the duel."

--- a/entities.py
+++ b/entities.py
@@ -56,6 +56,9 @@ class Player:
 
     brawls_won: int = 0
 
+    # Wins in the trading card duel mini-game
+    card_duels_won: int = 0
+
     enemies_defeated: int = 0
 
     boss_defeated: bool = False

--- a/game.py
+++ b/game.py
@@ -108,6 +108,8 @@ from helpers import (
     go_fishing,
     solve_puzzle,
     dig_for_treasure,
+    card_duel,
+    
     save_game,
     load_game,
     HOME_WIDTH,
@@ -916,7 +918,10 @@ def main():
                         else:
                             continue
                         shop_message_timer = 60
-                    elif in_building == "workshop":
+                elif in_building == "mall" and event.key == pygame.K_c:
+                    shop_message = card_duel(player)
+                    shop_message_timer = 60
+                elif in_building == "workshop":
                         if event.key == pygame.K_1:
                             if player.resources.get("herbs", 0) >= 2:
                                 player.resources["herbs"] -= 2
@@ -1562,7 +1567,7 @@ def main():
             elif near_building.btype == "business":
                 msg = "[E] manage or 1-2 buy"
             elif near_building.btype == "mall":
-                msg = "[E] to browse the mall"
+                msg = "[E] to browse the mall  [C] card duel"
             elif near_building.btype == "beach":
                 msg = "[E] to relax"
                 msg += "  [D] dig"
@@ -1635,7 +1640,7 @@ def main():
                     opts.append(f"{i+1}:{name} {status}")
                 txt = " ".join(opts) + "  E:Manage  [Q] Leave"
             elif in_building == "mall":
-                txt = "[E] Pick up order  [Q] Leave"
+                txt = "[E] Pick up order  C:Duel  [Q] Leave"
             elif in_building == "beach":
                 txt = "[E] Relax/Deliver  D:Dig  [Q] Leave"
             elif in_building == "suburbs":

--- a/quests.py
+++ b/quests.py
@@ -21,6 +21,8 @@ ACHIEVEMENT_EPITHETS = {
     "Wealthy": "the Rich",
     "Story Hero": "the Hero",
     "Boss Slayer": "the Slayer",
+    "Card Master": "the Duelist",
+    "Card Collector": "the Collector",
 }
 
 # Names of collectible trading cards
@@ -405,4 +407,18 @@ def check_achievements(player: Player) -> str | None:
         player.achievements.append("Boss Slayer")
         player.epithet = ACHIEVEMENT_EPITHETS.get("Boss Slayer", player.epithet)
         return "Achievement unlocked: Boss Slayer!"
+    if (
+        "Card Master" not in player.achievements
+        and player.card_duels_won >= 5
+    ):
+        player.achievements.append("Card Master")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Card Master", player.epithet)
+        return "Achievement unlocked: Card Master!"
+    if (
+        "Card Collector" not in player.achievements
+        and set(player.cards) >= set(CARD_NAMES)
+    ):
+        player.achievements.append("Card Collector")
+        player.epithet = ACHIEVEMENT_EPITHETS.get("Card Collector", player.epithet)
+        return "Achievement unlocked: Card Collector!"
     return None

--- a/tests/test_cardgame.py
+++ b/tests/test_cardgame.py
@@ -1,0 +1,16 @@
+import pygame
+import settings
+from entities import Player
+from cardgame import card_duel
+from unittest.mock import patch
+
+
+def test_card_duel_win_reward():
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.energy = 50
+    with patch('random.sample', side_effect=[["Slime", "Goblin", "Farmer"], ["Dragon", "Wizard", "Alien"]]):
+        with patch('random.choice', return_value="Robot"):
+            msg = card_duel(player)
+    assert msg.startswith("You won")
+    assert player.card_duels_won == 1
+    assert "Robot" in player.cards


### PR DESCRIPTION
## Summary
- add a simple card duel mini-game
- track duel wins in the Player dataclass
- unlock achievements for card duels and collecting all cards
- add card duel option at the mall
- test card duel logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837d89aa80832685db81d1f2e69e52