### PR TITLE
Add faction reputation system

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -148,6 +148,11 @@ class Player:
     last_talk: Dict[str, int] = field(default_factory=dict)
     romanced: List[str] = field(default_factory=list)
 
+    # Reputation with various city factions
+    reputation: Dict[str, int] = field(
+        default_factory=lambda: {"mayor": 0, "business": 0, "gang": 0}
+    )
+
 
 @dataclass
 class Quest:

--- a/factions.py
+++ b/factions.py
@@ -1,0 +1,29 @@
+"""Faction and reputation helpers."""
+from typing import Dict
+
+from entities import Player
+
+FACTIONS = ["mayor", "business", "gang"]
+
+
+def change_reputation(player: Player, faction: str, amount: int) -> None:
+    """Adjust reputation with a faction and clamp between -100 and 100."""
+    if faction not in FACTIONS:
+        return
+    rep = player.reputation.get(faction, 0) + amount
+    player.reputation[faction] = max(-100, min(100, rep))
+
+
+def business_price(player: Player, cost: int) -> int:
+    """Return item cost adjusted by business reputation."""
+    rep = player.reputation.get("business", 0)
+    multiplier = 1.0
+    if rep >= 50:
+        multiplier = 0.8
+    elif rep >= 20:
+        multiplier = 0.9
+    elif rep <= -50:
+        multiplier = 1.25
+    elif rep <= -20:
+        multiplier = 1.1
+    return int(round(cost * multiplier))

--- a/helpers.py
+++ b/helpers.py
@@ -423,6 +423,7 @@ def save_game(player: Player) -> None:
         "relationships": player.relationships,
         "last_talk": player.last_talk,
         "romanced": player.romanced,
+        "reputation": player.reputation,
         "x": player.rect.x,
         "y": player.rect.y,
         "quests": [q.completed for q in QUESTS],
@@ -535,6 +536,9 @@ def load_game() -> Optional[Player]:
     player.relationships = data.get("relationships", {})
     player.last_talk = data.get("last_talk", {})
     player.romanced = data.get("romanced", [])
+    player.reputation = data.get(
+        "reputation", {"mayor": 0, "business": 0, "gang": 0}
+    )
     for completed, q in zip(data.get("quests", []), QUESTS):
         q.completed = completed
     return player

--- a/inventory.py
+++ b/inventory.py
@@ -3,6 +3,7 @@
 from typing import List, Tuple
 from entities import Player, InventoryItem
 from combat import energy_cost
+import factions
 
 # Items sold at the shop: name, cost, and effect
 SHOP_ITEMS: List[Tuple[str, int, any]] = [
@@ -114,6 +115,7 @@ def buy_shop_item(player: Player, index: int) -> str:
     name, cost, effect = SHOP_ITEMS[index]
     if name == "Skateboard" and player.has_skateboard:
         return "Already have skateboard"
+    cost = factions.business_price(player, cost)
     if player.money < cost:
         return "Not enough money!"
     player.money -= cost

--- a/tests/test_factions.py
+++ b/tests/test_factions.py
@@ -1,0 +1,35 @@
+import pygame
+import settings
+from entities import Player
+from inventory import buy_shop_item
+from factions import change_reputation, business_price
+
+
+def make_player():
+    return Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+
+
+def test_change_reputation_clamped():
+    player = make_player()
+    change_reputation(player, "mayor", 120)
+    assert player.reputation["mayor"] == 100
+    change_reputation(player, "mayor", -250)
+    assert player.reputation["mayor"] == -100
+
+
+def test_business_price_adjustment():
+    player = make_player()
+    change_reputation(player, "business", 50)
+    assert business_price(player, 100) == 80
+    change_reputation(player, "business", -120)
+    assert business_price(player, 100) == 125
+
+
+def test_buy_shop_item_discount():
+    player = make_player()
+    change_reputation(player, "business", 50)
+    player.money = 5
+    msg = buy_shop_item(player, 0)  # Cola costs 3
+    assert msg == "Bought Cola"
+    # cost after 20% discount should be 2
+    assert player.money == 3


### PR DESCRIPTION
## Summary
- add `reputation` tracking to `Player`
- add new `factions` module with helper functions
- apply business reputation adjustments to shop prices
- persist reputation in save data
- test new reputation system

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d6ddc8d48326803c3ec4cd2aa2f8