### PR TITLE
Add NPC scheduling system

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -192,6 +192,11 @@ class NPC:
     gender: str = ""
     bubble_message: str = ""
     bubble_timer: int = 0
+    # daily schedule details
+    home: str = "suburbs"
+    work: Optional[str] = None
+    work_start: int = 9
+    work_end: int = 17
 
 
 @dataclass

--- a/game.py
+++ b/game.py
@@ -307,7 +307,7 @@ def main():
         if player.time >= 1440:
             player.time -= 1440
             advance_day(player)
-        update_npcs()
+        update_npcs(player, BUILDINGS)
         for ab, cd in player.ability_cooldowns.items():
             if cd > 0:
                 player.ability_cooldowns[ab] -= 1


### PR DESCRIPTION
## Summary
- extend `NPC` dataclass with home/work schedule fields
- assign a basic day schedule for each NPC
- move NPCs toward their scheduled locations in `update_npcs`
- update game loop to pass player and building data

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688771b194fc8326830929a694b35d93