### PR TITLE
Add advanced relationship milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ to complete your collection!
 
 A simple social system lets you befriend townsfolk. Talk to residents each day
 to earn hearts and give them items from your inventory for an extra boost. Reach
-eight hearts with someone to start dating them. Three characters can be
-romanced: **Alice**, **Bella**, and **Chris**.
+eight hearts with someone to start dating them. Building deeper friendships can
+uncover personal side quests and even lead to marriage once you hit ten hearts.
+Three characters can be romanced: **Alice**, **Bella**, and **Chris**.
 
 You can save your progress with **F5** and load it back with **F9**. If a
 `savegame.json` file exists, it will automatically be loaded when the game

--- a/data/sidequests.json
+++ b/data/sidequests.json
@@ -3,4 +3,7 @@
     {"name": "Courier Errand", "description": "Deliver a package from Sam to the Gym", "target": "gym", "reward": 30},
     {"name": "Beach Delivery", "description": "Pick up sunglasses from the Mall and bring them to the Beach", "target": "beach", "reward": 40},
     {"name": "Mayor Letter", "description": "Take a letter from the Mayor to the Library", "target": "library", "reward": 60}
+    ,{"name": "Alice's Concert", "description": "Attend a show with Alice at the Theater", "target": "theater", "reward": 100}
+    ,{"name": "Bella's Necklace", "description": "Find Bella's lost necklace near the Forest", "target": "forest", "reward": 80}
+    ,{"name": "Chris's Training", "description": "Spar with Chris at the Gym", "target": "gym", "reward": 70}
 ]

--- a/entities.py
+++ b/entities.py
@@ -147,6 +147,9 @@ class Player:
     relationships: Dict[str, int] = field(default_factory=dict)
     last_talk: Dict[str, int] = field(default_factory=dict)
     romanced: List[str] = field(default_factory=list)
+    # Additional relationship milestones and marriage state
+    relationship_stage: Dict[str, int] = field(default_factory=dict)
+    married_to: Optional[str] = None
 
     # Reputation with various city factions
     reputation: Dict[str, int] = field(

--- a/game.py
+++ b/game.py
@@ -60,6 +60,7 @@ from quests import (
     SIDE_QUEST,
     NPC_QUEST,
     MALL_QUEST,
+    RELATIONSHIP_QUESTS,
     NPCS,
     STORY_QUESTS,
     check_quests,
@@ -230,6 +231,8 @@ SECRET_PERKS = [
 
 # Maximum hearts an NPC can have
 MAX_HEARTS = 10
+REL_QUEST_THRESHOLD = 5
+MARRIAGE_THRESHOLD = MAX_HEARTS
 
 
 
@@ -1326,9 +1329,25 @@ def main():
                         player.relationships[near_npc.name] = hearts
                         player.last_talk[near_npc.name] = player.day
                         text = f"+1 heart ({hearts}/{MAX_HEARTS})"
+                        if (
+                            hearts >= REL_QUEST_THRESHOLD
+                            and player.relationship_stage.get(near_npc.name, 0) < 1
+                        ):
+                            quest = RELATIONSHIP_QUESTS.get(near_npc.name)
+                            if quest and player.side_quest is None:
+                                player.side_quest = quest.name
+                                player.relationship_stage[near_npc.name] = 1
+                                text = quest.description
                     if hearts >= 8 and near_npc.name not in player.romanced:
                         player.romanced.append(near_npc.name)
                         text = f"You are now dating {near_npc.name}!"
+                    if (
+                        hearts >= MARRIAGE_THRESHOLD
+                        and near_npc.name in player.romanced
+                        and player.married_to is None
+                    ):
+                        player.married_to = near_npc.name
+                        text = f"You married {near_npc.name}!"
                 elif near_npc.quest is None:
                     text = "Good to see you."
                 near_npc.bubble_message = text
@@ -1342,9 +1361,25 @@ def main():
                 player.relationships[near_npc.name] = hearts
                 player.last_talk[near_npc.name] = player.day
                 text = f"Gave {item.name}! ({hearts}/{MAX_HEARTS})"
+                if (
+                    hearts >= REL_QUEST_THRESHOLD
+                    and player.relationship_stage.get(near_npc.name, 0) < 1
+                ):
+                    quest = RELATIONSHIP_QUESTS.get(near_npc.name)
+                    if quest and player.side_quest is None:
+                        player.side_quest = quest.name
+                        player.relationship_stage[near_npc.name] = 1
+                        text = quest.description
                 if hearts >= 8 and near_npc.name not in player.romanced:
                     player.romanced.append(near_npc.name)
                     text = f"{near_npc.name} is now your partner!"
+                if (
+                    hearts >= MARRIAGE_THRESHOLD
+                    and near_npc.name in player.romanced
+                    and player.married_to is None
+                ):
+                    player.married_to = near_npc.name
+                    text = f"You married {near_npc.name}!"
                 near_npc.bubble_message = text
                 near_npc.bubble_timer = 90
                 shop_message = f"{near_npc.name}: {text}"

--- a/helpers.py
+++ b/helpers.py
@@ -423,6 +423,8 @@ def save_game(player: Player) -> None:
         "relationships": player.relationships,
         "last_talk": player.last_talk,
         "romanced": player.romanced,
+        "relationship_stage": player.relationship_stage,
+        "married_to": player.married_to,
         "reputation": player.reputation,
         "x": player.rect.x,
         "y": player.rect.y,
@@ -536,6 +538,8 @@ def load_game() -> Optional[Player]:
     player.relationships = data.get("relationships", {})
     player.last_talk = data.get("last_talk", {})
     player.romanced = data.get("romanced", [])
+    player.relationship_stage = data.get("relationship_stage", {})
+    player.married_to = data.get("married_to")
     player.reputation = data.get(
         "reputation", {"mayor": 0, "business": 0, "gang": 0}
     )

--- a/quests.py
+++ b/quests.py
@@ -59,6 +59,14 @@ SIDE_QUEST = SIDE_QUESTS.get("Bank Delivery")
 NPC_QUEST = SIDE_QUESTS.get("Courier Errand")
 MALL_QUEST = SIDE_QUESTS.get("Beach Delivery")
 MAYOR_QUEST = SIDE_QUESTS.get("Mayor Letter")
+ALICE_REL_QUEST = SIDE_QUESTS.get("Alice's Concert")
+BELLA_REL_QUEST = SIDE_QUESTS.get("Bella's Necklace")
+CHRIS_REL_QUEST = SIDE_QUESTS.get("Chris's Training")
+RELATIONSHIP_QUESTS = {
+    "Alice": ALICE_REL_QUEST,
+    "Bella": BELLA_REL_QUEST,
+    "Chris": CHRIS_REL_QUEST,
+}
 
 # Friendly townsfolk found around the city
 NPCS = [


### PR DESCRIPTION
## Summary
- allow player relationships to progress to side quests and marriage
- persist relationship milestones in save data
- expand NPC side quests data
- document deeper relationship options

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bfa2f6848326b654ded8e3ce97ad