### PR TITLE
Add companion ability training

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ The city also has a **Pet Shop** where you can adopt an animal companion.
 Available pets include a dog, cat, parrot, llama, peacock, and rhino. Pets
 grant small bonuses like extra defense or charisma and may help you find money
 or tokens. Companions can be trained at the Pet Shop to improve these bonuses
-and unlock stronger abilities.
+and unlock stronger abilities. Press **T** inside the shop to open the
+training menu and spend cash on unique pet abilities.
 
 A new **Workshop** lets you craft, upgrade, and now repair your gear. Fights and events can
 yield metal, cloth, and herbs. Spend these resources to brew Health Potions,

--- a/entities.py
+++ b/entities.py
@@ -65,6 +65,8 @@ class Player:
 
     companion: Optional[str] = None
     companion_level: int = 0
+    # Ability levels for each companion ability
+    companion_abilities: Dict[str, Dict[str, int]] = field(default_factory=dict)
 
     home_upgrades: List[str] = field(default_factory=list)
     perk_points: int = 0

--- a/helpers.py
+++ b/helpers.py
@@ -399,6 +399,7 @@ def save_game(player: Player) -> None:
         "boss_defeated": player.boss_defeated,
         "companion": player.companion,
         "companion_level": player.companion_level,
+        "companion_abilities": player.companion_abilities,
         "has_skateboard": player.has_skateboard,
         "home_upgrades": player.home_upgrades,
         "home_level": player.home_level,
@@ -502,6 +503,7 @@ def load_game() -> Optional[Player]:
     player.enemies_defeated = data.get("enemies_defeated", 0)
     player.companion = data.get("companion")
     player.companion_level = data.get("companion_level", 0)
+    player.companion_abilities = data.get("companion_abilities", {})
     player.npc_progress = data.get("npc_progress", {})
     player.story_stage = data.get("story_stage", 0)
     player.story_branch = data.get("story_branch")

--- a/rendering.py
+++ b/rendering.py
@@ -609,6 +609,31 @@ def draw_perk_menu(surface, font, player, perks):
     surface.blit(info, (100, 120 + len(perks) * 40 + 20))
 
 
+def draw_companion_menu(surface, font, player, abilities):
+    """Render the companion training menu."""
+    overlay = pygame.Surface((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 160))
+    surface.blit(overlay, (0, 0))
+
+    panel = pygame.Surface((settings.SCREEN_WIDTH - 120, settings.SCREEN_HEIGHT - 120))
+    panel.fill((240, 240, 220))
+    surface.blit(panel, (60, 60))
+
+    title = font.render("Train Companion", True, FONT_COLOR)
+    surface.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 70))
+
+    levels = player.companion_abilities.get(player.companion, {})
+    for i, (name, desc, _stat) in enumerate(abilities):
+        lvl = levels.get(name, 0)
+        txt = font.render(
+            f"{i+1}: {name} Lv{lvl}/{PERK_MAX_LEVEL} - {desc}", True, FONT_COLOR
+        )
+        surface.blit(txt, (100, 120 + i * 40))
+
+    info = font.render("[Q] Exit", True, FONT_COLOR)
+    surface.blit(info, (100, 120 + len(abilities) * 40 + 20))
+
+
 def draw_quest_log(surface, font, quests, story_quests=None):
     """Show completed and active quests."""
     overlay = pygame.Surface((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT), pygame.SRCALPHA)

--- a/tests/test_companion.py
+++ b/tests/test_companion.py
@@ -1,0 +1,15 @@
+import pygame
+import settings
+from entities import Player
+from inventory import adopt_companion, upgrade_companion_ability, COMPANION_ABILITIES
+
+
+def test_upgrade_companion_ability():
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.money = 200
+    player.energy = 100
+    adopt_companion(player, 0)  # Dog
+    msg = upgrade_companion_ability(player, 0)
+    ability_name = COMPANION_ABILITIES[player.companion][0][0]
+    assert ability_name in msg
+    assert player.companion_abilities[player.companion][ability_name] == 1


### PR DESCRIPTION
## Summary
- add companion ability trees and training system
- allow saving/loading companion abilities
- draw companion training menu
- expose training via T key at the Pet Shop
- document how to train pets
- test upgrading companion abilities

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c7b2a2008326b4c773daffc2fb14