### PR TITLE
Add seasonal festivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ through Spring, Summer, Fall, and Winter, each lasting about a month.
 Bad weather closes the park and deal spots, and special seasonal encounters
 offer small bonuses or penalties.
 
+Each season now begins with its own Festival side quest. Completing these
+limited-time quests or participating in seasonal events can earn unique
+rewards like extra tokens or produce. Keep an eye on the calendar so you
+don't miss out!
+
 Your apartment can also be improved. While inside the Home you can buy a Comfy
 Bed, Decorations, or a Study Desk. These upgrades boost your energy recovery
 and may grant daily bonuses when you sleep. Crafted furniture items can be

--- a/data/sidequests.json
+++ b/data/sidequests.json
@@ -6,4 +6,8 @@
     ,{"name": "Alice's Concert", "description": "Attend a show with Alice at the Theater", "target": "theater", "reward": 100}
     ,{"name": "Bella's Necklace", "description": "Find Bella's lost necklace near the Forest", "target": "forest", "reward": 80}
     ,{"name": "Chris's Training", "description": "Spar with Chris at the Gym", "target": "gym", "reward": 70}
+    ,{"name": "Spring Festival", "description": "Join the planting contest at the Farm", "target": "farm", "reward": 50}
+    ,{"name": "Summer Festival", "description": "Win tokens at the Beach party", "target": "beach", "reward": 50}
+    ,{"name": "Fall Festival", "description": "Help harvest crops for the town", "target": "farm", "reward": 50}
+    ,{"name": "Winter Festival", "description": "Enter the ice fishing tournament", "target": "park", "reward": 50}
 ]

--- a/helpers.py
+++ b/helpers.py
@@ -18,6 +18,7 @@ from quests import (
     NPC_QUEST,
     STORY_TARGETS,
     QUEST_TARGETS,
+    SEASONAL_QUESTS,
 )
 from combat import energy_cost
 from businesses import collect_profits
@@ -199,9 +200,18 @@ def building_open(btype: str, minutes: float, player: Player) -> bool:
 
 
 def update_weather(player: Player) -> None:
-    """Randomly set the current season and weather."""
+    """Randomly set the current season and weather.
+
+    When a new season begins, award the matching seasonal quest if the
+    player doesn't already have a side quest.
+    """
+    old_season = player.season
     season_index = ((player.day - 1) // 30) % len(SEASONS)
     player.season = SEASONS[season_index]
+    if player.season != old_season and player.side_quest is None:
+        quest = SEASONAL_QUESTS.get(player.season)
+        if quest:
+            player.side_quest = quest.name
     if player.season == "Winter":
         choices = ["Snow", "Snow", "Clear", "Rain"]
     elif player.season == "Summer":

--- a/quests.py
+++ b/quests.py
@@ -11,7 +11,11 @@ from loaders import load_quests, load_sidequests
 import pygame
 
 from entities import Player, Quest, Event, SideQuest, NPC
-from inventory import HOME_UPGRADES
+from inventory import (
+    HOME_UPGRADES,
+    plant_seed,
+    harvest_crops,
+)
 from combat import BRAWLER_COUNT
 
 # Epithets awarded for certain achievements
@@ -66,6 +70,14 @@ RELATIONSHIP_QUESTS = {
     "Alice": ALICE_REL_QUEST,
     "Bella": BELLA_REL_QUEST,
     "Chris": CHRIS_REL_QUEST,
+}
+
+# Seasonal side quests triggered at the start of each season
+SEASONAL_QUESTS = {
+    "Spring": SIDE_QUESTS.get("Spring Festival"),
+    "Summer": SIDE_QUESTS.get("Summer Festival"),
+    "Fall": SIDE_QUESTS.get("Fall Festival"),
+    "Winter": SIDE_QUESTS.get("Winter Festival"),
 }
 
 # Friendly townsfolk found around the city
@@ -226,11 +238,19 @@ SEASON_EVENTS = {
             "Flowers bloom brightly. +1 CHA",
             lambda p: setattr(p, "charisma", p.charisma + 1),
         ),
+        Event(
+            "Spring Planting Festival! You plant a seed",
+            lambda p: plant_seed(p),
+        ),
     ],
     "Summer": [
         Event(
             "Heat wave tires you out. -5 energy",
             lambda p: setattr(p, "energy", max(p.energy - 5, 0)),
+        ),
+        Event(
+            "Beach party games award you a token",
+            lambda p: setattr(p, "tokens", p.tokens + 1),
         ),
     ],
     "Fall": [
@@ -238,11 +258,19 @@ SEASON_EVENTS = {
             "Found $5 under fallen leaves",
             lambda p: setattr(p, "money", p.money + 5),
         ),
+        Event(
+            "Harvest Festival rewards extra crops",
+            lambda p: harvest_crops(p),
+        ),
     ],
     "Winter": [
         Event(
             "Cold wind toughens you. +1 DEF",
             lambda p: setattr(p, "defense", p.defense + 1),
+        ),
+        Event(
+            "Ice Fishing Derby time! You caught a fish",
+            lambda p: setattr(p, "money", p.money + 10),
         ),
     ],
 }


### PR DESCRIPTION
## Summary
- add new festival side quests to `sidequests.json`
- start these quests whenever the season changes
- include special seasonal events for each festival
- document festivals in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a0775bbe8832691d1e78d6d5aa02c