### PR TITLE
Implement dynamic item pricing

### DIFF
--- a/game.py
+++ b/game.py
@@ -38,6 +38,7 @@ from inventory import (
     COMPANIONS,
     buy_shop_item,
     buy_home_upgrade,
+    get_shop_price,
     bank_deposit,
     bank_withdraw,
     adopt_companion,
@@ -1731,9 +1732,10 @@ def main():
                 txt = "[E] Help locals  [Q] Leave"
             draw_tip_panel(screen, font, f"Inside: {in_building.upper()}   {txt}")
             if in_building == "shop":
-                for i, (name, cost, _func) in enumerate(SHOP_ITEMS):
+                for i, (name, _cost, _func) in enumerate(SHOP_ITEMS):
+                    price = get_shop_price(player, i)
                     item_surf = font.render(
-                        f"{(i + 1) % 10}:{name} ${cost}", True, (80, 40, 40)
+                        f"{(i + 1) % 10}:{name} ${price}", True, (80, 40, 40)
                     )
                     row = i // 5
                     col = i % 5

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,0 +1,24 @@
+import random
+import pygame
+import settings
+from entities import Player
+from inventory import get_shop_price, SHOP_ITEMS
+
+
+def make_player():
+    return Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+
+
+def test_shop_price_base():
+    player = make_player()
+    base = SHOP_ITEMS[0][1]
+    assert get_shop_price(player, 0) == base
+
+
+def test_shop_price_fluctuates():
+    player = make_player()
+    player.day = 2
+    player.season = "Winter"
+    r = random.Random(player.day).random()
+    expected = int(round(SHOP_ITEMS[0][1] * 1.2 * (0.8 + r * 0.4)))
+    assert get_shop_price(player, 0) == expected


### PR DESCRIPTION
## Summary
- add daily and seasonal multipliers for shop item pricing
- use dynamic pricing when rendering shop items
- test new economy behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b572bafa08326a3954f24c58e9304