### PR TITLE
Add procedural dungeon feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Outside the city gates lies a small **Woods** area. Three stationary foes wait
 here, each tougher than the last. Approach an enemy and press **E** to engage
 in battle for a cash reward.
 
+Hidden entrances now lead to procedural **Sewers** beneath the city. Each run
+randomly selects a few enemies based on those in the woods. Clear every room to
+earn a piece of unique loot like a Sewer Dagger, encouraging repeat dives.
+
 The city also has a **Pet Shop** where you can adopt an animal companion.
 Available pets include a dog, cat, parrot, llama, peacock, and rhino. Pets
 grant small bonuses like extra defense or charisma and may help you find money

--- a/dungeons.py
+++ b/dungeons.py
@@ -1,0 +1,43 @@
+import random
+from typing import List, Dict
+
+from entities import Player, InventoryItem
+from combat import FOREST_ENEMIES, fight_custom_enemy
+
+
+DUNGEON_LOOT: List[InventoryItem] = [
+    InventoryItem("Sewer Dagger", "weapon", attack=3, speed=1),
+    InventoryItem("Sewer Armor", "chest", defense=3),
+    InventoryItem("Old Coin", "consumable"),
+]
+
+
+def generate_dungeon() -> List[Dict[str, int]]:
+    """Create a list of random enemies for a dungeon run."""
+    rooms = random.randint(2, 4)
+    enemies = []
+    for _ in range(rooms):
+        base = random.choice(FOREST_ENEMIES)
+        enemy = {
+            "attack": random.randint(max(1, base["attack"] - 1), base["attack"] + 1),
+            "defense": random.randint(base["defense"], base["defense"] + 1),
+            "speed": random.randint(base["speed"], base["speed"] + 1),
+            "health": base["health"] + random.randint(-5, 5),
+            "reward": base["reward"],
+        }
+        enemies.append(enemy)
+    return enemies
+
+
+def explore_dungeon(player: Player) -> str:
+    """Run a short procedural dungeon and return the result message."""
+    if player.energy < 10:
+        return "Too tired to explore!"
+    enemies = generate_dungeon()
+    for enemy in enemies:
+        result = fight_custom_enemy(player, enemy)
+        if "lost" in result:
+            return "You were defeated in the dungeon!"
+    loot = random.choice(DUNGEON_LOOT)
+    player.inventory.append(loot)
+    return f"Dungeon cleared! You found {loot.name}"

--- a/game.py
+++ b/game.py
@@ -60,6 +60,7 @@ from combat import (
     fight_forest_enemy,
     fight_final_boss,
 )
+from dungeons import explore_dungeon
 from quests import (
     QUESTS,
     SIDE_QUEST,
@@ -934,7 +935,7 @@ def main():
                         continue
                     shop_message_timer = 60
                 elif in_building == "dungeon" and event.key == pygame.K_e:
-                    shop_message = fight_enemy(player)
+                    shop_message = explore_dungeon(player)
                     shop_message_timer = 60
                 elif in_building == "boss" and event.key == pygame.K_e:
                     shop_message = fight_final_boss(player)
@@ -963,7 +964,7 @@ def main():
                             continue
                         shop_message_timer = 60
                     elif in_building == "dungeon" and event.key == pygame.K_e:
-                        shop_message = fight_enemy(player)
+                        shop_message = explore_dungeon(player)
                         shop_message_timer = 60
                     elif in_building == "boss" and event.key == pygame.K_e:
                         shop_message = fight_final_boss(player)
@@ -1663,7 +1664,7 @@ def main():
                 msg = "[E] to gamble and fight"
                 msg += "  [D] darts"
             elif near_building.btype == "dungeon":
-                msg = "[E] to fight an enemy"
+                msg = "[E] to explore the sewers"
             elif near_building.btype == "forest":
                 msg = "[E] to explore the woods"
             elif near_building.btype == "petshop":
@@ -1733,7 +1734,7 @@ def main():
                     "[F] Fight  [Q] Leave"
                 )
             elif in_building == "dungeon":
-                txt = "[E] Fight  [Q] Leave"
+                txt = "[E] Explore  [Q] Leave"
             elif in_building == "forest":
                 txt = "[E] Fight  [Q] Leave"
             elif in_building == "boss":

--- a/tests/test_dungeons.py
+++ b/tests/test_dungeons.py
@@ -1,0 +1,24 @@
+import random
+import pygame
+import settings
+from entities import Player
+from dungeons import explore_dungeon
+
+
+def test_explore_dungeon_rewards_loot():
+    random.seed(0)
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.energy = 100
+    player.strength = 10
+    player.defense = 5
+    count = len(player.inventory)
+    msg = explore_dungeon(player)
+    assert "Dungeon cleared" in msg
+    assert len(player.inventory) == count + 1
+
+
+def test_explore_dungeon_tired():
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.energy = 5
+    msg = explore_dungeon(player)
+    assert msg == "Too tired to explore!"


### PR DESCRIPTION
## Summary
- create `dungeons.py` with sewer generation helpers
- expose `fight_custom_enemy` and integrate in dungeon runs
- hook sewers into `game.py` and display explore prompts
- describe sewers in README
- test dungeon logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc28c6bfc8326b45d3639dbed4188