### PR TITLE
Add difficulty levels and rewards to minigames

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ contain friendly neighbors who sometimes need a hand, the bustling **Mall**
 offers a short delivery side quest, and a sunny **Beach** lets you relax. You
 can also dig for treasure there, sometimes uncovering valuable seashells.
 
-The bar, park, library, and beach each feature a simple minigame. Throw darts in
-the bar to win extra tokens, fish at the park for cash or herbs, solve a daily
-puzzle at the library for a small money reward, or dig for buried treasure on
-the beach. Lucky diggers might uncover a **Golden Seashell** decoration or a
-stylish **Pearl Necklace**.
+The bar, park, library, and beach each feature upgradeable minigames. Throw
+darts in the bar, play blackjack, or fish at the park with adjustable
+difficulty. Mastering hard mode can award extra tokens, achievements, and even
+exclusive trading cards like **Dart Master** or **Fishing Legend**. The library
+still offers a daily puzzle for a small money reward, and you can dig for
+buried treasure on the beach. Lucky diggers might uncover a **Golden Seashell**
+decoration or a stylish **Pearl Necklace**.
 
 Weather now changes each day with rain or snow possible. The world cycles
 through Spring, Summer, Fall, and Winter, each lasting about a month.

--- a/quests.py
+++ b/quests.py
@@ -41,6 +41,10 @@ CARD_NAMES = [
     "Pirate",
     "Robot",
     "Alien",
+    # Special cards earned from minigame achievements
+    "Dart Master",
+    "Blackjack Shark",
+    "Fishing Legend",
 ]
 
 # Storyline quests completed in order

--- a/tests/test_minigames.py
+++ b/tests/test_minigames.py
@@ -1,0 +1,44 @@
+import pygame
+import settings
+from entities import Player
+from helpers import play_darts, go_fishing, play_blackjack
+from unittest.mock import patch
+
+
+def make_player():
+    return Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+
+
+def test_darts_hard_grants_card():
+    player = make_player()
+    player.tokens = 1
+    player.speed = 4
+    with patch('random.randint', return_value=20):
+        msg = play_darts(player, difficulty='hard')
+    assert "Bullseye" in msg
+    assert player.tokens == 3
+    assert "Darts Champion" in player.achievements
+    assert "Dart Master" in player.cards
+
+
+def test_blackjack_perfect_score_unlocks_rewards():
+    player = make_player()
+    player.tokens = 1
+    with patch('random.randint', side_effect=[21, 18]):
+        msg = play_blackjack(player, difficulty='hard')
+    assert "You win" in msg
+    assert player.tokens == 3
+    assert "Blackjack Champion" in player.achievements
+    assert "Blackjack Shark" in player.cards
+
+
+def test_fishing_hard_big_catch_rewards():
+    player = make_player()
+    player.energy = 50
+    with patch('random.random', side_effect=[0.6, 0.6]):
+        with patch('random.randint', return_value=30):
+            msg = go_fishing(player, difficulty='hard')
+    assert msg.startswith("Caught a fish")
+    assert player.money >= 30
+    assert "Master Angler" in player.achievements
+    assert "Fishing Legend" in player.cards


### PR DESCRIPTION
## Summary
- expand blackjack, darts and fishing with difficulty settings and achievement-based rewards
- add new collectible cards unlocked by high scores
- document upgradeable minigames and card rewards in the README

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e1a24d22c832686e787c84c724992