### PR TITLE
Scale layouts and fonts to window size

### DIFF
--- a/game.py
+++ b/game.py
@@ -139,6 +139,7 @@ from helpers import (
     FOREST_WIDTH,
     FOREST_HEIGHT,
     FOREST_DOOR_RECT,
+    scaled_font,
 )
 from menus import start_menu, character_creation
 
@@ -252,7 +253,7 @@ def main():
     )
     pygame.display.set_caption("Stick RPG Mini (Graphics Upgrade)")
     clock = pygame.time.Clock()
-    font = pygame.font.SysFont(None, 28)
+    font = scaled_font(28)
 
     if start_menu(screen, font):
         loaded = load_game()
@@ -309,7 +310,7 @@ def main():
         hotkey_rects = compute_hotkey_rects()
         pygame.display.set_caption("Stick RPG Mini (Graphics Upgrade)")
         self.clock = pygame.time.Clock()
-        self.font = pygame.font.SysFont(None, 28)
+        self.font = scaled_font(28)
 
         if start_menu(self.screen, self.font):
             loaded = load_game()
@@ -416,6 +417,7 @@ def main():
                     recalc_layouts()
                     slot_rects = compute_slot_rects()
                     hotkey_rects = compute_hotkey_rects()
+                    font = scaled_font(28)
                 elif event.key == pygame.K_m and SOUND_ENABLED:
                     muted = not muted
                     vol = 0 if muted else SFX_VOLUME

--- a/helpers.py
+++ b/helpers.py
@@ -25,17 +25,16 @@ from businesses import collect_profits
 import settings
 
 
+BASE_SCREEN_W, BASE_SCREEN_H = 1600, 1200
+
+
 # --- Layout helpers -------------------------------------------------------
 
 HOME_WIDTH = settings.SCREEN_WIDTH
 HOME_HEIGHT = settings.SCREEN_HEIGHT
-BED_RECT = pygame.Rect(120, 160, 220, 120)
-DOOR_RECT = pygame.Rect(HOME_WIDTH // 2 - 60, HOME_HEIGHT - 180, 120, 160)
-FURNITURE_RECTS = [
-    pygame.Rect(360 + col * 150, HOME_HEIGHT // 2 - 80 + row * 100, 120, 80)
-    for row in range(3)
-    for col in range(3)
-]
+BED_RECT = pygame.Rect(0, 0, 0, 0)
+DOOR_RECT = pygame.Rect(0, 0, 0, 0)
+FURNITURE_RECTS: List[pygame.Rect] = []
 
 # Bonuses granted when sleeping with certain furniture placed
 FURNITURE_BONUSES: Dict[str, Dict[str, int]] = {
@@ -44,21 +43,27 @@ FURNITURE_BONUSES: Dict[str, Dict[str, int]] = {
 
 BAR_WIDTH = settings.SCREEN_WIDTH
 BAR_HEIGHT = settings.SCREEN_HEIGHT
-BAR_DOOR_RECT = pygame.Rect(BAR_WIDTH // 2 - 60, BAR_HEIGHT - 180, 120, 160)
-COUNTER_RECT = pygame.Rect(60, BAR_HEIGHT // 2 - 60, 180, 120)
-BJ_RECT = pygame.Rect(BAR_WIDTH // 2 - 100, BAR_HEIGHT // 2 - 150, 200, 100)
-SLOT_RECT = pygame.Rect(BAR_WIDTH - 240, BAR_HEIGHT // 2 - 60, 180, 120)
-BRAWL_RECT = pygame.Rect(BAR_WIDTH // 2 - 80, 80, 160, 120)
-DART_RECT = pygame.Rect(BAR_WIDTH // 2 - 100, BAR_HEIGHT // 2 + 60, 200, 100)
+BAR_DOOR_RECT = pygame.Rect(0, 0, 0, 0)
+COUNTER_RECT = pygame.Rect(0, 0, 0, 0)
+BJ_RECT = pygame.Rect(0, 0, 0, 0)
+SLOT_RECT = pygame.Rect(0, 0, 0, 0)
+BRAWL_RECT = pygame.Rect(0, 0, 0, 0)
+DART_RECT = pygame.Rect(0, 0, 0, 0)
 
 FOREST_WIDTH = settings.SCREEN_WIDTH
 FOREST_HEIGHT = settings.SCREEN_HEIGHT
-FOREST_DOOR_RECT = pygame.Rect(FOREST_WIDTH // 2 - 60, FOREST_HEIGHT - 180, 120, 160)
+FOREST_DOOR_RECT = pygame.Rect(0, 0, 0, 0)
+
+
+def scaled_font(base_size: int) -> pygame.font.Font:
+    """Return a font scaled relative to the window height."""
+    scale = settings.SCREEN_HEIGHT / BASE_SCREEN_H
+    return pygame.font.SysFont(None, int(base_size * scale))
 
 
 def recalc_layouts() -> None:
     """Update layout rects when the window size changes."""
-    global HOME_WIDTH, HOME_HEIGHT, DOOR_RECT
+    global HOME_WIDTH, HOME_HEIGHT, BED_RECT, DOOR_RECT
     global BAR_WIDTH, BAR_HEIGHT, BAR_DOOR_RECT, COUNTER_RECT
     global BJ_RECT, SLOT_RECT, BRAWL_RECT, DART_RECT
     global FOREST_WIDTH, FOREST_HEIGHT, FOREST_DOOR_RECT
@@ -66,29 +71,87 @@ def recalc_layouts() -> None:
 
     HOME_WIDTH = settings.SCREEN_WIDTH
     HOME_HEIGHT = settings.SCREEN_HEIGHT
-    DOOR_RECT = pygame.Rect(HOME_WIDTH // 2 - 60, HOME_HEIGHT - 180, 120, 160)
 
-    BAR_WIDTH = settings.SCREEN_WIDTH
-    BAR_HEIGHT = settings.SCREEN_HEIGHT
-    BAR_DOOR_RECT = pygame.Rect(BAR_WIDTH // 2 - 60, BAR_HEIGHT - 180, 120, 160)
-    COUNTER_RECT = pygame.Rect(60, BAR_HEIGHT // 2 - 60, 180, 120)
-    BJ_RECT = pygame.Rect(BAR_WIDTH // 2 - 100, BAR_HEIGHT // 2 - 150, 200, 100)
-    SLOT_RECT = pygame.Rect(BAR_WIDTH - 240, BAR_HEIGHT // 2 - 60, 180, 120)
-    BRAWL_RECT = pygame.Rect(BAR_WIDTH // 2 - 80, 80, 160, 120)
-    DART_RECT = pygame.Rect(BAR_WIDTH // 2 - 100, BAR_HEIGHT // 2 + 60, 200, 100)
-
-    FOREST_WIDTH = settings.SCREEN_WIDTH
-    FOREST_HEIGHT = settings.SCREEN_HEIGHT
-    FOREST_DOOR_RECT = pygame.Rect(
-        FOREST_WIDTH // 2 - 60, FOREST_HEIGHT - 180, 120, 160
+    # Home layout ratios based on the original 1600x1200 resolution
+    bed = (
+        int(HOME_WIDTH * 0.075),
+        int(HOME_HEIGHT * 0.1333),
+        int(HOME_WIDTH * 0.1375),
+        int(HOME_HEIGHT * 0.1),
+    )
+    BED_RECT = pygame.Rect(*bed)
+    door_w = int(HOME_WIDTH * 0.075)
+    door_h = int(HOME_HEIGHT * 0.1333)
+    DOOR_RECT = pygame.Rect(
+        int(HOME_WIDTH * 0.5 - HOME_WIDTH * 0.0375),
+        int(HOME_HEIGHT * 0.85),
+        door_w,
+        door_h,
     )
 
+    col_spacing = int(HOME_WIDTH * 0.09375)
+    row_spacing = int(HOME_HEIGHT * 0.0833)
+    base_x = int(HOME_WIDTH * 0.225)
+    base_y = int(HOME_HEIGHT * 0.4333)
+    furn_w = int(HOME_WIDTH * 0.075)
+    furn_h = int(HOME_HEIGHT * 0.0667)
     FURNITURE_RECTS = [
-        pygame.Rect(360 + col * 150, HOME_HEIGHT // 2 - 80 + row * 100, 120, 80)
+        pygame.Rect(base_x + col * col_spacing, base_y + row * row_spacing, furn_w, furn_h)
         for row in range(3)
         for col in range(3)
     ]
 
+    BAR_WIDTH = settings.SCREEN_WIDTH
+    BAR_HEIGHT = settings.SCREEN_HEIGHT
+    BAR_DOOR_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.5 - BAR_WIDTH * 0.0375),
+        int(BAR_HEIGHT * 0.85),
+        door_w,
+        door_h,
+    )
+    COUNTER_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.0375),
+        int(BAR_HEIGHT * 0.45),
+        int(BAR_WIDTH * 0.1125),
+        int(BAR_HEIGHT * 0.1),
+    )
+    BJ_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.4375),
+        int(BAR_HEIGHT * 0.375),
+        int(BAR_WIDTH * 0.125),
+        int(BAR_HEIGHT * 0.0833),
+    )
+    SLOT_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.85),
+        int(BAR_HEIGHT * 0.45),
+        int(BAR_WIDTH * 0.1125),
+        int(BAR_HEIGHT * 0.1),
+    )
+    BRAWL_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.45),
+        int(BAR_HEIGHT * 0.0667),
+        int(BAR_WIDTH * 0.1),
+        int(BAR_HEIGHT * 0.1),
+    )
+    DART_RECT = pygame.Rect(
+        int(BAR_WIDTH * 0.4375),
+        int(BAR_HEIGHT * 0.55),
+        int(BAR_WIDTH * 0.125),
+        int(BAR_HEIGHT * 0.0833),
+    )
+
+    FOREST_WIDTH = settings.SCREEN_WIDTH
+    FOREST_HEIGHT = settings.SCREEN_HEIGHT
+    FOREST_DOOR_RECT = pygame.Rect(
+        int(FOREST_WIDTH * 0.5 - FOREST_WIDTH * 0.0375),
+        int(FOREST_HEIGHT * 0.85),
+        door_w,
+        door_h,
+    )
+
+
+# Initialize rects using current screen size
+recalc_layouts()
 
 # --- Inventory UI helpers -------------------------------------------------
 
@@ -97,8 +160,9 @@ def compute_slot_rects() -> Dict[str, pygame.Rect]:
     """Return rects for each equipment slot."""
     left = settings.SCREEN_WIDTH // 10
     top = settings.SCREEN_HEIGHT // 6
-    w, h = 100, 60
-    spacing = 70
+    w = int(settings.SCREEN_WIDTH * 0.0625)
+    h = int(settings.SCREEN_HEIGHT * 0.05)
+    spacing = int(settings.SCREEN_HEIGHT * 0.0583)
     return {
         "head": pygame.Rect(left, top, w, h),
         "chest": pygame.Rect(left, top + spacing, w, h),
@@ -110,10 +174,13 @@ def compute_slot_rects() -> Dict[str, pygame.Rect]:
 
 def compute_hotkey_rects() -> List[pygame.Rect]:
     """Return rects for quick item hotkey slots."""
-    base = settings.SCREEN_WIDTH // 2 - 170
-    y = settings.SCREEN_HEIGHT - 80
-    w, h = 60, 40
-    return [pygame.Rect(base + i * 70, y, w, h) for i in range(5)]
+    w = int(settings.SCREEN_WIDTH * 0.0375)
+    h = int(settings.SCREEN_HEIGHT * 0.0333)
+    spacing = int(settings.SCREEN_WIDTH * 0.04375)
+    total_width = w + spacing * 4
+    base = settings.SCREEN_WIDTH // 2 - total_width // 2
+    y = settings.SCREEN_HEIGHT - int(settings.SCREEN_HEIGHT * 0.0667)
+    return [pygame.Rect(base + i * spacing, y, w, h) for i in range(5)]
 
 
 def compute_furniture_rects(player: Player) -> List[pygame.Rect]:
@@ -452,6 +519,7 @@ def dig_for_treasure(player: Player) -> str:
     player.inventory.append(
         InventoryItem("Pearl Necklace", "chest", defense=1, speed=1)
     )
+
     return "You dug up a Pearl Necklace!"
 
 

--- a/menus.py
+++ b/menus.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pygame
 
-from helpers import recalc_layouts, compute_slot_rects
+from helpers import recalc_layouts, compute_slot_rects, scaled_font
 from quests import LEADERBOARD_FILE
 import settings
 
@@ -31,6 +31,7 @@ def start_menu(screen: pygame.Surface, font: pygame.font.Font) -> bool:
                 screen = pygame.display.set_mode((event.w, event.h), pygame.RESIZABLE)
                 recalc_layouts()
                 slot_rects = compute_slot_rects()
+                font = scaled_font(28)
             if event.type == pygame.KEYDOWN:
                 if event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     return False

--- a/rendering.py
+++ b/rendering.py
@@ -35,6 +35,7 @@ from tilemap import TileMap
 from careers import get_job_title, job_progress
 from inventory import crafting_exp_needed
 from constants import PERK_MAX_LEVEL
+from helpers import scaled_font
 
 PLAYER_SPRITES = []
 PLAYER_SPRITE_COLOR = None
@@ -224,7 +225,7 @@ def draw_building(surface, building, highlight=False):
             dy = b.y + b.height - 38
             pygame.draw.rect(surface, DOOR_COLOR, (dx, dy, 36, 38), border_radius=5)
             pygame.draw.circle(surface, (220, 210, 120), (dx + 32, dy + 19), 3)
-    font = pygame.font.SysFont(None, 28)
+    font = scaled_font(28)
     label = font.render(building.name, True, FONT_COLOR)
     label_bg = pygame.Surface(
         (label.get_width() + 12, label.get_height() + 4), pygame.SRCALPHA
@@ -716,12 +717,18 @@ def draw_help_screen(surface, font):
 
 def draw_tip_panel(surface, font, text):
     """Display an instruction panel at the bottom of the screen."""
-    panel_height = 100
+    panel_height = int(settings.SCREEN_HEIGHT * 0.0833)
     panel = pygame.Surface((settings.SCREEN_WIDTH, panel_height))
     panel.fill((245, 245, 200))
     surface.blit(panel, (0, settings.SCREEN_HEIGHT - panel_height))
     tip_surf = font.render(text, True, (80, 40, 40))
-    surface.blit(tip_surf, (20, settings.SCREEN_HEIGHT - 80))
+    surface.blit(
+        tip_surf,
+        (
+            int(settings.SCREEN_WIDTH * 0.0125),
+            settings.SCREEN_HEIGHT - panel_height + int(panel_height * 0.2),
+        ),
+    )
 
 
 def draw_hotkey_bar(surface, font, player, rects):
@@ -729,39 +736,52 @@ def draw_hotkey_bar(surface, font, player, rects):
     for i, rect in enumerate(rects):
         pygame.draw.rect(surface, (210, 210, 210), rect)
         label = font.render(str(i + 1), True, FONT_COLOR)
-        surface.blit(label, (rect.x + 2, rect.y - 18))
+        surface.blit(
+            label,
+            (rect.x + int(rect.width * 0.033), rect.y - int(rect.height * 0.45)),
+        )
         item = player.hotkeys[i]
         if item:
             txt = font.render(item.name, True, FONT_COLOR)
-            surface.blit(txt, (rect.x + 4, rect.y + 10))
+            surface.blit(
+                txt,
+                (rect.x + int(rect.width * 0.067), rect.y + int(rect.height * 0.25)),
+            )
 
 
 def draw_home_interior(surface, font, player, frame, bed_rect, door_rect, furn_rects):
     """Draw a simple interior of the player's home."""
     surface.fill((235, 225, 200))
     # walls
-    pygame.draw.rect(surface, (160, 140, 110), (0, 0, settings.SCREEN_WIDTH, 40))
+    wall = int(settings.SCREEN_WIDTH * 0.025)
+    pygame.draw.rect(surface, (160, 140, 110), (0, 0, settings.SCREEN_WIDTH, wall))
     pygame.draw.rect(
         surface,
         (160, 140, 110),
-        (0, settings.SCREEN_HEIGHT - 40, settings.SCREEN_WIDTH, 40),
+        (0, settings.SCREEN_HEIGHT - wall, settings.SCREEN_WIDTH, wall),
     )
-    pygame.draw.rect(surface, (160, 140, 110), (0, 0, 40, settings.SCREEN_HEIGHT))
+    pygame.draw.rect(surface, (160, 140, 110), (0, 0, wall, settings.SCREEN_HEIGHT))
     pygame.draw.rect(
         surface,
         (160, 140, 110),
-        (settings.SCREEN_WIDTH - 40, 0, 40, settings.SCREEN_HEIGHT),
+        (settings.SCREEN_WIDTH - wall, 0, wall, settings.SCREEN_HEIGHT),
     )
 
     # bed
     pygame.draw.rect(surface, (200, 70, 70), bed_rect)
-    pygame.draw.rect(surface, (255, 255, 255), bed_rect.inflate(-20, -20))
+    pygame.draw.rect(
+        surface,
+        (255, 255, 255),
+        bed_rect.inflate(
+            -int(bed_rect.width * 0.09), -int(bed_rect.height * 0.167)
+        ),
+    )
 
     # door
     pygame.draw.rect(surface, (100, 80, 60), door_rect)
-    pygame.draw.circle(
-        surface, (220, 210, 120), (door_rect.right - 20, door_rect.centery), 6
-    )
+    knob_x = door_rect.right - int(door_rect.width * 0.167)
+    knob_r = max(1, int(door_rect.width * 0.05))
+    pygame.draw.circle(surface, (220, 210, 120), (knob_x, door_rect.centery), knob_r)
 
     for idx, rect in enumerate(furn_rects):
         pygame.draw.rect(surface, (200, 190, 150), rect)
@@ -769,7 +789,10 @@ def draw_home_interior(surface, font, player, frame, bed_rect, door_rect, furn_r
         item = player.furniture.get(slot)
         if item:
             txt = font.render(item.name, True, FONT_COLOR)
-            surface.blit(txt, (rect.x + 4, rect.y + 20))
+            surface.blit(
+                txt,
+                (rect.x + int(rect.width * 0.033), rect.y + int(rect.height * 0.25)),
+            )
 
     draw_player_sprite(
         surface, player.rect, frame, player.facing_left, player.color, player.head_color
@@ -796,9 +819,9 @@ def draw_forest_area(surface, font, player, frame, enemy_rects, door_rect):
     surface.fill((50, 140, 70))
 
     pygame.draw.rect(surface, (100, 80, 60), door_rect)
-    pygame.draw.circle(
-        surface, (220, 210, 120), (door_rect.right - 20, door_rect.centery), 6
-    )
+    knob_x = door_rect.right - int(door_rect.width * 0.167)
+    knob_r = max(1, int(door_rect.width * 0.05))
+    pygame.draw.circle(surface, (220, 210, 120), (knob_x, door_rect.centery), knob_r)
 
     images = load_forest_enemy_images()
     for rect, img in zip(enemy_rects, images):
@@ -824,51 +847,86 @@ def draw_bar_interior(
     """Draw the interior of the bar with simple interaction spots."""
     surface.fill((225, 205, 170))
 
-    pygame.draw.rect(surface, (160, 140, 110), (0, 0, settings.SCREEN_WIDTH, 40))
+    wall = int(settings.SCREEN_WIDTH * 0.025)
+    pygame.draw.rect(surface, (160, 140, 110), (0, 0, settings.SCREEN_WIDTH, wall))
     pygame.draw.rect(
         surface,
         (160, 140, 110),
-        (0, settings.SCREEN_HEIGHT - 40, settings.SCREEN_WIDTH, 40),
+        (0, settings.SCREEN_HEIGHT - wall, settings.SCREEN_WIDTH, wall),
     )
-    pygame.draw.rect(surface, (160, 140, 110), (0, 0, 40, settings.SCREEN_HEIGHT))
+    pygame.draw.rect(surface, (160, 140, 110), (0, 0, wall, settings.SCREEN_HEIGHT))
     pygame.draw.rect(
         surface,
         (160, 140, 110),
-        (settings.SCREEN_WIDTH - 40, 0, 40, settings.SCREEN_HEIGHT),
+        (settings.SCREEN_WIDTH - wall, 0, wall, settings.SCREEN_HEIGHT),
     )
 
     # counter for buying tokens
     pygame.draw.rect(surface, (120, 80, 60), counter_rect)
-    pygame.draw.rect(surface, (180, 140, 100), counter_rect.inflate(-20, -20))
+    pygame.draw.rect(
+        surface,
+        (180, 140, 100),
+        counter_rect.inflate(
+            -int(counter_rect.width * 0.111), -int(counter_rect.height * 0.167)
+        ),
+    )
     ct = font.render("Tokens", True, FONT_COLOR)
     surface.blit(
-        ct, (counter_rect.x + 20, counter_rect.y + counter_rect.height // 2 - 10)
+        ct,
+        (
+            counter_rect.x + int(counter_rect.width * 0.111),
+            counter_rect.y + counter_rect.height // 2 - ct.get_height() // 2,
+        ),
     )
 
     # blackjack table
     pygame.draw.rect(surface, (60, 120, 60), bj_rect)
     bj = font.render("Blackjack", True, (250, 250, 250))
-    surface.blit(bj, (bj_rect.x + 20, bj_rect.y + bj_rect.height // 2 - 10))
+    surface.blit(
+        bj,
+        (
+            bj_rect.x + int(bj_rect.width * 0.1),
+            bj_rect.y + bj_rect.height // 2 - bj.get_height() // 2,
+        ),
+    )
 
     # slots
     pygame.draw.rect(surface, (90, 90, 150), slot_rect)
     sl = font.render("Slots", True, (250, 250, 250))
-    surface.blit(sl, (slot_rect.x + 20, slot_rect.y + slot_rect.height // 2 - 10))
+    surface.blit(
+        sl,
+        (
+            slot_rect.x + int(slot_rect.width * 0.111),
+            slot_rect.y + slot_rect.height // 2 - sl.get_height() // 2,
+        ),
+    )
 
     # darts board
     pygame.draw.rect(surface, (120, 70, 120), dart_rect)
     dr = font.render("Darts", True, (250, 250, 250))
-    surface.blit(dr, (dart_rect.x + 20, dart_rect.y + dart_rect.height // 2 - 10))
+    surface.blit(
+        dr,
+        (
+            dart_rect.x + int(dart_rect.width * 0.1),
+            dart_rect.y + dart_rect.height // 2 - dr.get_height() // 2,
+        ),
+    )
 
     # fighting ring
     pygame.draw.rect(surface, (180, 70, 70), brawl_rect)
     fb = font.render("Fight", True, (250, 250, 250))
-    surface.blit(fb, (brawl_rect.x + 20, brawl_rect.y + brawl_rect.height // 2 - 10))
+    surface.blit(
+        fb,
+        (
+            brawl_rect.x + int(brawl_rect.width * 0.125),
+            brawl_rect.y + brawl_rect.height // 2 - fb.get_height() // 2,
+        ),
+    )
 
     pygame.draw.rect(surface, (100, 80, 60), door_rect)
-    pygame.draw.circle(
-        surface, (220, 210, 120), (door_rect.right - 20, door_rect.centery), 6
-    )
+    knob_x = door_rect.right - int(door_rect.width * 0.167)
+    knob_r = max(1, int(door_rect.width * 0.05))
+    pygame.draw.circle(surface, (220, 210, 120), (knob_x, door_rect.centery), knob_r)
 
     draw_player_sprite(
         surface, player.rect, frame, player.facing_left, player.color, player.head_color


### PR DESCRIPTION
## Summary
- Compute world and UI layouts as percentages of the window size
- Scale fonts dynamically with window height and update on resize
- Replace hard-coded drawing offsets with rect-based calculations

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a2c30cc0832680e867b1fd4d3648