### PR TITLE
Add minimap rendering and toggle

### DIFF
--- a/game.py
+++ b/game.py
@@ -31,6 +31,7 @@ from rendering import (
     draw_help_screen,
     draw_quest_marker,
     draw_companion_menu,
+    draw_minimap,
 )
 from inventory import (
     SHOP_ITEMS,
@@ -282,6 +283,7 @@ def main():
         show_craft_menu = False
         show_log = False
         show_help = False
+        show_minimap = False
         dragging_item = None
         drag_rotation = 0
         shop_message = ""
@@ -304,6 +306,7 @@ def main():
         show_craft_menu = False
         show_log = False
         show_help = False
+        show_minimap = False
         dragging_item = None
         drag_rotation = 0
         shop_message = ""
@@ -431,6 +434,8 @@ def main():
                         pygame.mixer.music.set_volume(0 if muted else MUSIC_VOLUME)
                     shop_message = "Sound muted" if muted else "Sound on"
                     shop_message_timer = 60
+                elif event.key == pygame.K_TAB:
+                    show_minimap = not show_minimap
                 elif (
                     event.key == pygame.K_h
                     and not show_inventory
@@ -1530,6 +1535,9 @@ def main():
 
         draw_day_night(screen, player.time)
         draw_weather(screen, player.weather)
+
+        if show_minimap:
+            draw_minimap(screen, player.rect, BUILDINGS, NPCS, target_building)
 
         draw_ui(screen, font, player, QUESTS, STORY_QUESTS)
         draw_hotkey_bar(screen, font, player, hotkey_rects)

--- a/rendering.py
+++ b/rendering.py
@@ -247,6 +247,50 @@ def draw_building(surface, building, highlight=False):
     surface.blit(label, (b.x + b.width // 2 - label.get_width() // 2, b.y - 30))
 
 
+def draw_minimap(surface, player_rect, buildings, npcs=None, target=None, scale=0.1):
+    """Render a simple minimap showing buildings, NPCs and the player."""
+    width = int(MAP_WIDTH * scale)
+    height = int(MAP_HEIGHT * scale)
+    minimap = pygame.Surface((width, height), pygame.SRCALPHA)
+    minimap.fill(UI_BG)
+    minimap.set_alpha(200)
+
+    # draw buildings
+    for b in buildings:
+        rect = pygame.Rect(
+            int(b.rect.x * scale),
+            int(b.rect.y * scale),
+            max(2, int(b.rect.width * scale)),
+            max(2, int(b.rect.height * scale)),
+        )
+        pygame.draw.rect(minimap, building_color(b.btype), rect)
+
+    # quest target highlight
+    if target:
+        rect = pygame.Rect(
+            int(target.rect.x * scale),
+            int(target.rect.y * scale),
+            max(2, int(target.rect.width * scale)),
+            max(2, int(target.rect.height * scale)),
+        )
+        pygame.draw.rect(minimap, (255, 0, 0), rect, 2)
+
+    # draw NPCs
+    if npcs:
+        for n in npcs:
+            x = int(n.rect.centerx * scale)
+            y = int(n.rect.centery * scale)
+            pygame.draw.circle(minimap, (0, 0, 255), (x, y), 3)
+
+    # draw player
+    px = int(player_rect.centerx * scale)
+    py = int(player_rect.centery * scale)
+    pygame.draw.circle(minimap, (255, 255, 255), (px, py), 4)
+
+    pygame.draw.rect(minimap, (255, 255, 255), minimap.get_rect(), 1)
+    surface.blit(minimap, (SCREEN_WIDTH - width - 10, 10))
+
+
 def draw_road_and_sidewalks(surface, cam_x, cam_y):
     """Render the city ground using a tile map."""
     global CITY_MAP


### PR DESCRIPTION
## Summary
- add `draw_minimap` to render scaled map with buildings, NPCs, player and quest highlight
- allow toggling the minimap with Tab and render it during play

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689745dd42648326990b42d99bc794d9