### PR TITLE
Add auto-save helper and integrate with game events

### DIFF
--- a/game.py
+++ b/game.py
@@ -124,9 +124,10 @@ from helpers import (
     solve_puzzle,
     dig_for_treasure,
     card_duel,
-    
+
     save_game,
     load_game,
+    auto_save,
     HOME_WIDTH,
     HOME_HEIGHT,
     BED_RECT,
@@ -372,12 +373,18 @@ def main():
             )
 
 
+    frame = 0
+    last_autosave_hour = player.time // 60
     while True:
         frame += 1
         player.time += MINUTES_PER_FRAME
         if player.time >= 1440:
             player.time -= 1440
             advance_day(player)
+        current_hour = player.time // 60
+        if current_hour != last_autosave_hour:
+            last_autosave_hour = current_hour
+            auto_save(player)
         update_npcs(player, BUILDINGS)
         for ab, cd in player.ability_cooldowns.items():
             if cd > 0:
@@ -734,6 +741,7 @@ def main():
                         if idx < len(avail):
                             full_idx = HOME_UPGRADES.index(avail[idx])
                             shop_message = buy_home_upgrade(player, full_idx)
+                            auto_save(player)
                         else:
                             shop_message = "Invalid choice"
                         shop_message_timer = 60
@@ -813,6 +821,7 @@ def main():
                             idx = event.key - pygame.K_1
                             shop_message = buy_home_upgrade(player, idx)
                             shop_message_timer = 60
+                            auto_save(player)
                         else:
                             continue
                     elif in_building == "shop":
@@ -820,9 +829,11 @@ def main():
                             idx = event.key - pygame.K_1
                             shop_message = buy_shop_item(player, idx)
                             shop_message_timer = 60
+                            auto_save(player)
                         elif event.key == pygame.K_0:
                             shop_message = buy_shop_item(player, 9)
                             shop_message_timer = 60
+                            auto_save(player)
                         elif _event_matches("interact", event):
                             shop_message = "Press number keys to buy"
                             shop_message_timer = 60
@@ -1859,8 +1870,10 @@ def main():
             pygame.time.wait(2500)
             return
 
-        if check_quests(player) and SOUND_ENABLED:
-            quest_sound.play()
+        if check_quests(player):
+            auto_save(player)
+            if SOUND_ENABLED:
+                quest_sound.play()
 
         pygame.display.flip()
         clock.tick(60)

--- a/helpers.py
+++ b/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import random
+import time
 from typing import Dict, List, Optional
 
 import pygame
@@ -607,6 +608,34 @@ def save_game(player: Player) -> None:
     }
     with open(SAVE_FILE, "w") as f:
         json.dump(data, f)
+
+
+_last_auto_save = 0.0
+
+
+def auto_save(player: Player, cooldown: float = 60.0) -> bool:
+    """Automatically save the game if the cooldown has elapsed.
+
+    Parameters
+    ----------
+    player:
+        The current player instance whose state should be saved.
+    cooldown:
+        Minimum number of real-time seconds between automatic saves.
+
+    Returns
+    -------
+    bool
+        ``True`` if the game was saved, ``False`` otherwise.
+    """
+
+    global _last_auto_save
+    now = time.time()
+    if now - _last_auto_save >= cooldown:
+        save_game(player)
+        _last_auto_save = now
+        return True
+    return False
 
 
 def load_game() -> Optional[Player]:


### PR DESCRIPTION
## Summary
- Add `auto_save` helper with cooldown around `save_game`
- Auto-save on hourly ticks, quest completion, and purchases

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899fb5680d8832692e4cd430637ac0a