### PR TITLE
Add companion morale mechanic

### DIFF
--- a/combat.py
+++ b/combat.py
@@ -50,7 +50,7 @@ def energy_cost(player: Player, base: float) -> float:
     return cost
 
 
-def _combat_stats(player: Player) -> Tuple[int, int, int, int]:
+def _combat_stats(player: Player) -> Tuple[float, float, float, int]:
     """Return player's attack, defense, speed and combo with equipment."""
     weapon = player.equipment.get("weapon")
     base_atk = player.strength
@@ -67,10 +67,11 @@ def _combat_stats(player: Player) -> Tuple[int, int, int, int]:
     combo = 1
     if player.perk_levels.get("Bar Champion"):
         atk += 2
+    morale = player.companion_morale / 100 if player.companion else 0
     if player.companion == "Dog":
-        df += 1
+        df += 1 * morale
     elif player.companion == "Rhino":
-        atk += 1
+        atk += 1 * morale
     for item in player.equipment.values():
         if item and item.durability > 0:
             atk += item.attack
@@ -247,7 +248,8 @@ def fight_enemy(player: Player) -> str:
         player.resources[res] = player.resources.get(res, 0) + 1
         loot += f" +1 {res}"
     if player.companion == "Parrot":
-        chance = 0.3 + 0.2 * (player.companion_level - 1)
+        morale = player.companion_morale / 100
+        chance = (0.3 + 0.2 * (player.companion_level - 1)) * morale
         if random.random() < chance:
             player.tokens += 1
             loot += " (parrot found another)"

--- a/entities.py
+++ b/entities.py
@@ -68,6 +68,7 @@ class Player:
 
     companion: Optional[str] = None
     companion_level: int = 0
+    companion_morale: int = 100
     # Ability levels for each companion ability
     companion_abilities: Dict[str, Dict[str, int]] = field(default_factory=dict)
 

--- a/helpers.py
+++ b/helpers.py
@@ -561,6 +561,7 @@ def save_game(player: Player) -> None:
         "boss_defeated": player.boss_defeated,
         "companion": player.companion,
         "companion_level": player.companion_level,
+        "companion_morale": player.companion_morale,
         "companion_abilities": player.companion_abilities,
         "has_skateboard": player.has_skateboard,
         "home_upgrades": player.home_upgrades,
@@ -695,6 +696,7 @@ def load_game() -> Optional[Player]:
     player.enemies_defeated = data.get("enemies_defeated", 0)
     player.companion = data.get("companion")
     player.companion_level = data.get("companion_level", 0)
+    player.companion_morale = data.get("companion_morale", 100)
     player.companion_abilities = data.get("companion_abilities", {})
     player.npc_progress = data.get("npc_progress", {})
     player.story_stage = data.get("story_stage", 0)

--- a/inventory.py
+++ b/inventory.py
@@ -248,6 +248,7 @@ def adopt_companion(player: Player, index: int) -> str:
     player.money -= cost
     player.companion = name
     player.companion_level = 1
+    player.companion_morale = 100
     player.companion_abilities[name] = {
         abil[0]: 0 for abil in COMPANION_ABILITIES.get(name, [])
     }
@@ -326,6 +327,8 @@ def feed_animals(player: Player, animal: str) -> str:
     products = {"chicken": "eggs", "cow": "milk"}
     product = products[animal]
     player.resources[product] = player.resources.get(product, 0) + count
+    if player.companion:
+        player.companion_morale = min(100, player.companion_morale + 5)
     return f"Collected {count} {product}"
 
 
@@ -362,6 +365,7 @@ def train_companion(player: Player) -> str:
     player.money -= cost
     player.energy -= energy_cost(player, 10)
     player.companion_level += 1
+    player.companion_morale = max(0, player.companion_morale - 10)
     if player.companion == "Dog":
         player.defense += 1
     elif player.companion == "Cat":

--- a/rendering.py
+++ b/rendering.py
@@ -698,15 +698,20 @@ def draw_companion_menu(surface, font, player, abilities):
     surface.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 70))
 
     levels = player.companion_abilities.get(player.companion, {})
+    morale_txt = font.render(
+        f"Morale: {player.companion_morale}", True, FONT_COLOR
+    )
+    surface.blit(morale_txt, (100, 100))
+    offset = 20
     for i, (name, desc, _stat) in enumerate(abilities):
         lvl = levels.get(name, 0)
         txt = font.render(
             f"{i+1}: {name} Lv{lvl}/{PERK_MAX_LEVEL} - {desc}", True, FONT_COLOR
         )
-        surface.blit(txt, (100, 120 + i * 40))
+        surface.blit(txt, (100, 120 + i * 40 + offset))
 
     info = font.render("[Q] Exit", True, FONT_COLOR)
-    surface.blit(info, (100, 120 + len(abilities) * 40 + 20))
+    surface.blit(info, (100, 120 + len(abilities) * 40 + offset + 20))
 
 
 def draw_quest_log(surface, font, quests, story_quests=None):

--- a/tests/test_companion_morale.py
+++ b/tests/test_companion_morale.py
@@ -1,0 +1,19 @@
+import pygame
+from entities import Player
+from inventory import adopt_companion, feed_animals, train_companion
+
+
+def test_companion_morale_adjustments():
+    player = Player(pygame.Rect(0, 0, 10, 10))
+    player.money = 1000
+    adopt_companion(player, 0)  # Dog
+    assert player.companion_morale == 100
+
+    player.animals["chicken"] = 1
+    player.companion_morale = 90
+    feed_animals(player, "chicken")
+    assert player.companion_morale == 95
+
+    player.companion_morale = 15
+    train_companion(player)
+    assert player.companion_morale == 5


### PR DESCRIPTION
## Summary
- Add companion morale to `Player` and persist it to saves
- Adjust adoption, feeding, and training to modify morale
- Scale combat bonuses and token find chance by companion morale
- Show morale in companion menu

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c61909e80832693349f1d50c54d7c