### PR TITLE
Add business marketing and staff training mechanics

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -95,6 +95,10 @@ class Player:
     business_bonus: Dict[str, int] = field(default_factory=dict)
     # Number of staff hired for each business
     business_staff: Dict[str, int] = field(default_factory=dict)
+    # Temporary reputation boosts from marketing
+    business_reputation: Dict[str, int] = field(default_factory=dict)
+    # Temporary staff skill training to reduce robberies
+    business_skill: Dict[str, int] = field(default_factory=dict)
 
     # Tracks per-NPC interaction states
     npc_progress: Dict[str, int] = field(default_factory=dict)

--- a/game.py
+++ b/game.py
@@ -58,7 +58,13 @@ from inventory import (
     craft_recipe,
     RECIPES,
 )
-from businesses import BUSINESSES, buy_business, manage_business
+from businesses import (
+    BUSINESSES,
+    buy_business,
+    manage_business,
+    run_marketing_campaign,
+    train_staff,
+)
 from loaders import load_buildings
 from combat import (
     energy_cost,
@@ -934,7 +940,32 @@ def main():
                     elif in_building == "park" and event.key == pygame.K_f:
                         shop_message = go_fishing(player)
                         shop_message_timer = 60
-
+                    elif in_building == "business":
+                        if pygame.K_1 <= event.key <= pygame.K_9:
+                            idx = event.key - pygame.K_1
+                            shop_message = buy_business(player, idx)
+                        elif event.key == pygame.K_e:
+                            name = next(iter(player.businesses), None)
+                            if name:
+                                shop_message = manage_business(player, name)
+                            else:
+                                shop_message = "No businesses owned"
+                        elif event.key == pygame.K_m:
+                            name = next(iter(player.businesses), None)
+                            if name:
+                                shop_message = run_marketing_campaign(player, name)
+                            else:
+                                shop_message = "No businesses owned"
+                        elif event.key == pygame.K_t:
+                            name = next(iter(player.businesses), None)
+                            if name:
+                                shop_message = train_staff(player, name)
+                            else:
+                                shop_message = "No businesses owned"
+                        else:
+                            continue
+                        shop_message_timer = 60
+                        auto_save(player)
                     else:
                         continue
                 elif in_building == "gym" and _event_matches("interact", event):
@@ -1821,7 +1852,7 @@ def main():
                 for i, (name, cost, _p) in enumerate(BUSINESSES):
                     status = "Owned" if name in player.businesses else f"${cost}"
                     opts.append(f"{i+1}:{name} {status}")
-                txt = " ".join(opts) + "  E:Manage  [Q] Leave"
+                txt = " ".join(opts) + "  E:Manage M:Market T:Train  [Q] Leave"
             elif in_building == "mall":
                 txt = "[E] Pick up order  C:Duel  [Q] Leave"
             elif in_building == "beach":

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -9,6 +9,8 @@ from businesses import (
     upgrade_business,
     hire_staff,
     collect_profits,
+    run_marketing_campaign,
+    train_staff,
 )
 
 
@@ -60,4 +62,52 @@ def test_robbery_zeroes_profit():
         random.random = orig_random
 
     assert profit == 0
+
+
+def test_marketing_campaign_boosts_profit():
+    p = make_player()
+    p.money = 10000
+    store_index = BUSINESS_CATALOG.index("Store")
+    buy_business(p, store_index)
+    orig_randint = random.randint
+    random.randint = lambda a, b: a
+    try:
+        run_marketing_campaign(p, "Store")
+    finally:
+        random.randint = orig_randint
+    orig_random = random.random
+    random.random = lambda: 1.0
+    try:
+        profit = collect_profits(p)
+    finally:
+        random.random = orig_random
+    data = BUSINESS_DATA["Store"]
+    expected = data.base_profit + p.charisma * 2 + 10
+    assert profit == expected
+
+
+def test_train_staff_reduces_robbery_risk():
+    p = make_player()
+    p.money = 10000
+    stall_index = BUSINESS_CATALOG.index("Stall")
+    buy_business(p, stall_index)
+    orig_random = random.random
+    random.random = lambda: 0.05
+    try:
+        profit = collect_profits(p)
+    finally:
+        random.random = orig_random
+    assert profit == 0
+    orig_randint = random.randint
+    random.randint = lambda a, b: 3
+    try:
+        train_staff(p, "Stall")
+    finally:
+        random.randint = orig_randint
+    random.random = lambda: 0.05
+    try:
+        profit_after = collect_profits(p)
+    finally:
+        random.random = orig_random
+    assert profit_after > 0
 


### PR DESCRIPTION
## Summary
- Add marketing campaign and staff training actions for businesses
- Track reputation and staff skill to influence profits and robbery risk
- Expose marketing and training options in business management menu

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f35042c648326bb3c7c1008b9a079