### PR TITLE
Add skill-based crafting system

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -2,28 +2,35 @@
     {
         "name": "Health Potion",
         "requires": {"herbs": 2},
+        "skill": "alchemy",
+        "level": 1,
         "produces": {"name": "Health Potion", "slot": "consumable"}
     },
     {
         "name": "Iron Sword",
         "requires": {"metal": 3},
+        "skill": "smithing",
+        "level": 1,
         "produces": {"name": "Iron Sword", "slot": "weapon", "attack": 4}
     },
     {
         "name": "Energy Potion",
         "requires": {"herbs": 3},
+        "skill": "alchemy",
         "level": 2,
         "produces": {"name": "Energy Potion", "slot": "consumable"}
     },
     {
         "name": "Flaming Sword",
         "requires": {"metal": 5, "herbs": 2},
+        "skill": "smithing",
         "level": 3,
         "produces": {"name": "Flaming Sword", "slot": "weapon", "attack": 6}
     },
     {
         "name": "Fruit Pie",
         "requires": {"produce": 2},
+        "skill": "cooking",
         "level": 3,
         "produces": {"name": "Fruit Pie", "slot": "consumable"}
     }

--- a/entities.py
+++ b/entities.py
@@ -40,8 +40,9 @@ class Player:
     dealer_exp: int = 0
     clinic_exp: int = 0
     tokens: int = 0
-    crafting_level: int = 1
-    crafting_exp: int = 0
+    # Crafting skills and experience per skill
+    crafting_skills: Dict[str, int] = field(default_factory=dict)
+    crafting_exp: Dict[str, int] = field(default_factory=dict)
     # Names of crafting recipes the player has discovered
     known_recipes: List[str] = field(default_factory=list)
     has_skateboard: bool = False

--- a/game.py
+++ b/game.py
@@ -1152,8 +1152,8 @@ def main():
                             continue
                         shop_message_timer = 60
                     elif event.key == pygame.K_5:
-                        if player.crafting_level < 2:
-                            shop_message = "Need Craft Lv2"
+                        if player.crafting_skills.get("smithing", 1) < 2:
+                            shop_message = "Need Smithing Lv2"
                         elif (
                             player.resources.get("metal", 0) >= 1
                             and player.resources.get("cloth", 0) >= 2
@@ -1168,28 +1168,28 @@ def main():
                                     InventoryItem("Decor Chair", "furniture")
                                 )
                                 shop_message = "Crafted Decor Chair"
-                            lvl_msg = gain_crafting_exp(player)
+                            lvl_msg = gain_crafting_exp(player, "smithing")
                             if lvl_msg:
                                 shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 1 metal & 2 cloth"
                     elif event.key == pygame.K_6:
-                        if player.crafting_level < 2:
-                            shop_message = "Need Craft Lv2"
+                        if player.crafting_skills.get("alchemy", 1) < 2:
+                            shop_message = "Need Alchemy Lv2"
                         elif player.resources.get("herbs", 0) >= 3:
                             player.resources["herbs"] -= 3
                             player.inventory.append(
                                 InventoryItem("Energy Potion", "consumable")
                             )
                             shop_message = "Brewed Energy Potion"
-                            lvl_msg = gain_crafting_exp(player)
+                            lvl_msg = gain_crafting_exp(player, "alchemy")
                             if lvl_msg:
                                 shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 3 herbs"
                     elif event.key == pygame.K_7:
-                        if player.crafting_level < 3:
-                            shop_message = "Need Craft Lv3"
+                        if player.crafting_skills.get("smithing", 1) < 3:
+                            shop_message = "Need Smithing Lv3"
                         elif (
                             player.resources.get("metal", 0) >= 5
                             and player.resources.get("herbs", 0) >= 2
@@ -1200,21 +1200,21 @@ def main():
                                 InventoryItem("Flaming Sword", "weapon", attack=6)
                             )
                             shop_message = "Forged Flaming Sword"
-                            lvl_msg = gain_crafting_exp(player)
+                            lvl_msg = gain_crafting_exp(player, "smithing")
                             if lvl_msg:
                                 shop_message += f"  {lvl_msg}"
                         else:
                             shop_message = "Need 5 metal & 2 herbs"
                     elif event.key == pygame.K_8:
-                        if player.crafting_level < 3:
-                            shop_message = "Need Craft Lv3"
+                        if player.crafting_skills.get("cooking", 1) < 3:
+                            shop_message = "Need Cooking Lv3"
                         elif player.resources.get("produce", 0) >= 2:
                             player.resources["produce"] -= 2
                             player.inventory.append(
                                 InventoryItem("Fruit Pie", "consumable")
                             )
                             shop_message = "Baked Fruit Pie"
-                            lvl_msg = gain_crafting_exp(player)
+                            lvl_msg = gain_crafting_exp(player, "cooking")
                             if lvl_msg:
                                 shop_message += f"  {lvl_msg}"
 
@@ -1890,19 +1890,19 @@ def main():
                     screen.blit(item_surf, (30 + i * 200, settings.SCREEN_HEIGHT - 60))
             elif in_building == "workshop":
                 opts = [
-                    ("1:Health Potion (2 herbs)", 1),
-                    ("2:Iron Sword (3 metal)", 1),
-                    ("3:Upgrade Weapon (2 metal)", 1),
-                    ("4:Upgrade Armor (2 cloth)", 1),
-                    ("5:Decorations (1 metal,2 cloth)", 2),
-                    ("6:Energy Potion (3 herbs)", 2),
-                    ("7:Flaming Sword (5 metal,2 herbs)", 3),
-                    ("8:Fruit Pie (2 produce)", 3),
-                    ("9:Repair Gear (1 metal)", 1),
+                    ("1:Health Potion (2 herbs)", "alchemy", 1),
+                    ("2:Iron Sword (3 metal)", "smithing", 1),
+                    ("3:Upgrade Weapon (2 metal)", "smithing", 1),
+                    ("4:Upgrade Armor (2 cloth)", "smithing", 1),
+                    ("5:Decorations (1 metal,2 cloth)", "smithing", 2),
+                    ("6:Energy Potion (3 herbs)", "alchemy", 2),
+                    ("7:Flaming Sword (5 metal,2 herbs)", "smithing", 3),
+                    ("8:Fruit Pie (2 produce)", "cooking", 3),
+                    ("9:Repair Gear (1 metal)", "smithing", 1),
                 ]
-                for i, (txt_opt, req) in enumerate(opts):
-                    if player.crafting_level < req:
-                        txt_opt += f" [Lv{req}]"
+                for i, (txt_opt, skill, req) in enumerate(opts):
+                    if player.crafting_skills.get(skill, 1) < req:
+                        txt_opt += f" [{skill.title()} Lv{req}]"
                     item_surf = font.render(txt_opt, True, (80, 40, 40))
                     screen.blit(item_surf, (30 + i * 300, settings.SCREEN_HEIGHT - 60))
             elif in_building == "farm":

--- a/helpers.py
+++ b/helpers.py
@@ -554,7 +554,7 @@ def save_game(player: Player) -> None:
         "dealer_exp": player.dealer_exp,
         "clinic_exp": player.clinic_exp,
         "tokens": player.tokens,
-        "crafting_level": player.crafting_level,
+        "crafting_skills": player.crafting_skills,
         "crafting_exp": player.crafting_exp,
         "brawls_won": player.brawls_won,
         "enemies_defeated": player.enemies_defeated,
@@ -676,8 +676,8 @@ def load_game() -> Optional[Player]:
     player.clinic_shifts = data.get("clinic_shifts", player.clinic_shifts)
     player.clinic_exp = data.get("clinic_exp", 0)
     player.tokens = data.get("tokens", player.tokens)
-    player.crafting_level = data.get("crafting_level", 1)
-    player.crafting_exp = data.get("crafting_exp", 0)
+    player.crafting_skills = data.get("crafting_skills", {})
+    player.crafting_exp = data.get("crafting_exp", {})
     player.brawls_won = data.get("brawls_won", 0)
     player.enemies_defeated = data.get("enemies_defeated", 0)
     player.boss_defeated = data.get("boss_defeated", False)

--- a/menus.py
+++ b/menus.py
@@ -10,6 +10,7 @@ import pygame
 from helpers import recalc_layouts, compute_slot_rects, scaled_font
 from quests import LEADERBOARD_FILE
 import settings
+from inventory import crafting_exp_needed
 
 
 def _binding_name(code: int) -> str:
@@ -154,18 +155,44 @@ def draw_workshop_menu(surface: pygame.Surface, font: pygame.font.Font, player, 
     title = font.render("Workshop", True, settings.FONT_COLOR)
     surface.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 70))
 
+    y = 120
+    if player.crafting_skills:
+        for skill, lvl in player.crafting_skills.items():
+            xp = player.crafting_exp.get(skill, 0)
+            needed = crafting_exp_needed(player, skill)
+            prog = font.render(
+                f"{skill.title()} Lv{lvl} {xp}/{needed}",
+                True,
+                settings.FONT_COLOR,
+            )
+            surface.blit(prog, (100, y))
+            y += 40
+    else:
+        txt = font.render("No crafting skills", True, settings.FONT_COLOR)
+        surface.blit(txt, (100, y))
+        y += 40
+
     if not player.known_recipes:
         txt = font.render("No recipes known", True, settings.FONT_COLOR)
-        surface.blit(txt, (100, 120))
+        surface.blit(txt, (100, y))
     else:
         for i, name in enumerate(player.known_recipes):
             recipe = recipes.get(name, {})
-            reqs = ", ".join(f"{amt} {res}" for res, amt in recipe.get("requires", {}).items())
-            line = font.render(f"{i+1}: {name} - {reqs}", True, settings.FONT_COLOR)
-            surface.blit(line, (100, 120 + i * 40))
+            reqs = ", ".join(
+                f"{amt} {res}" for res, amt in recipe.get("requires", {}).items()
+            )
+            skill = recipe.get("skill", "crafting").title()
+            lvl = recipe.get("level", 1)
+            line = font.render(
+                f"{i+1}: {name} ({skill} Lv{lvl}) - {reqs}",
+                True,
+                settings.FONT_COLOR,
+            )
+            surface.blit(line, (100, y + i * 40))
 
+    info_y = y + len(player.known_recipes) * 40 + 20
     info = font.render("[Q] Exit  [R] Repair", True, settings.FONT_COLOR)
-    surface.blit(info, (100, 120 + len(player.known_recipes) * 40 + 20))
+    surface.blit(info, (100, info_y))
 
 
 def character_creation(screen: pygame.Surface, font: pygame.font.Font):

--- a/rendering.py
+++ b/rendering.py
@@ -504,8 +504,7 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         f"C:{player.resources.get('cloth', 0)} "
         f"H:{player.resources.get('herbs', 0)} "
         f"S:{player.resources.get('seeds', 0)} "
-        f"P:{player.resources.get('produce', 0)} "
-        f"Craft:{player.crafting_level}",
+        f"P:{player.resources.get('produce', 0)}",
         True,
         FONT_COLOR,
     )
@@ -518,7 +517,14 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         FONT_COLOR,
     )
     bar.blit(card_stat, (settings.SCREEN_WIDTH - card_stat.get_width() - 20, 20))
-    craft_prog = f"{player.crafting_exp}/{crafting_exp_needed(player)}"
+    if player.crafting_skills:
+        first = next(iter(player.crafting_skills))
+        level = player.crafting_skills[first]
+        xp = player.crafting_exp.get(first, 0)
+        needed = crafting_exp_needed(player, first)
+        craft_prog = f"{first.title()} {level} {xp}/{needed}"
+    else:
+        craft_prog = "No Crafting"
     craft_txt = font.render(f"Craft XP: {craft_prog}", True, FONT_COLOR)
     bar.blit(craft_txt, (settings.SCREEN_WIDTH - craft_txt.get_width() - 20, 32))
     season_txt = font.render(f"{player.season} - {player.weather}", True, FONT_COLOR)

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -6,13 +6,13 @@ from inventory import crafting_exp_needed, CRAFT_EXP_BASE, craft_recipe
 
 def test_crafting_exp_needed_level1():
     player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
-    assert crafting_exp_needed(player) == CRAFT_EXP_BASE
+    assert crafting_exp_needed(player, "alchemy") == CRAFT_EXP_BASE
 
 
 def test_crafting_exp_needed_higher_level():
     player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
-    player.crafting_level = 3
-    assert crafting_exp_needed(player) == CRAFT_EXP_BASE * 3
+    player.crafting_skills["alchemy"] = 3
+    assert crafting_exp_needed(player, "alchemy") == CRAFT_EXP_BASE * 3
 
 
 def test_craft_requires_known_recipe():
@@ -27,4 +27,14 @@ def test_craft_requires_known_recipe():
     assert "Crafted Health Potion" in msg
     assert player.resources["herbs"] == 3
     assert any(it.name == "Health Potion" for it in player.inventory)
+
+
+def test_craft_requires_skill_level():
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.resources["metal"] = 5
+    player.resources["herbs"] = 2
+    player.known_recipes.append("Flaming Sword")
+    player.crafting_skills["smithing"] = 2
+    msg = craft_recipe(player, "Flaming Sword")
+    assert msg == "Need Smithing Lv3"
 


### PR DESCRIPTION
## Summary
- Track crafting levels and XP per skill on the player
- Require specific skills for recipes and award skill XP when crafting
- Show skill progress and recipe requirements in the workshop menu

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d04224c08325afbfd1f9de0d5dfd