### PR TITLE
Add room-based dungeon exploration with traps and branching paths

### DIFF
--- a/dungeons.py
+++ b/dungeons.py
@@ -1,8 +1,18 @@
 import random
-from typing import List, Dict
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
 
-from entities import Player, InventoryItem
+from entities import InventoryItem, Player
 from combat import FOREST_ENEMIES, fight_custom_enemy
+
+
+@dataclass
+class Room:
+    """A single dungeon room with enemies, optional trap and exits."""
+
+    enemies: List[Dict[str, int]]
+    trap: Optional[str]
+    exits: List[int]
 
 
 DUNGEON_LOOT: List[InventoryItem] = [
@@ -11,33 +21,119 @@ DUNGEON_LOOT: List[InventoryItem] = [
     InventoryItem("Old Coin", "consumable"),
 ]
 
-
-def generate_dungeon() -> List[Dict[str, int]]:
-    """Create a list of random enemies for a dungeon run."""
-    rooms = random.randint(2, 4)
-    enemies = []
-    for _ in range(rooms):
-        base = random.choice(FOREST_ENEMIES)
-        enemy = {
-            "attack": random.randint(max(1, base["attack"] - 1), base["attack"] + 1),
-            "defense": random.randint(base["defense"], base["defense"] + 1),
-            "speed": random.randint(base["speed"], base["speed"] + 1),
-            "health": base["health"] + random.randint(-5, 5),
-            "reward": base["reward"],
-        }
-        enemies.append(enemy)
-    return enemies
+# Rewards for rooms that only contain traps or puzzles
+TRAP_LOOT: List[InventoryItem] = [
+    InventoryItem("Healing Herb", "consumable"),
+    InventoryItem("Shiny Pebble", "consumable"),
+]
 
 
-def explore_dungeon(player: Player) -> str:
+TRAPS = ["spike trap", "pit trap", "ancient puzzle"]
+
+
+def _random_enemy() -> Dict[str, int]:
+    base = random.choice(FOREST_ENEMIES)
+    enemy = {
+        "attack": random.randint(max(1, base["attack"] - 1), base["attack"] + 1),
+        "defense": random.randint(base["defense"], base["defense"] + 1),
+        "speed": random.randint(base["speed"], base["speed"] + 1),
+        "health": base["health"] + random.randint(-5, 5),
+        "reward": base["reward"],
+    }
+    return enemy
+
+
+def generate_dungeon() -> List[Room]:
+    """Create a graph of connected rooms with random traps or puzzles."""
+
+    room_count = random.randint(2, 4)
+    rooms: List[Room] = []
+    for _ in range(room_count):
+        enemy_count = random.randint(0, 2)
+        enemies = [_random_enemy() for _ in range(enemy_count)]
+        trap = random.choice(TRAPS + [None])
+        rooms.append(Room(enemies=enemies, trap=trap, exits=[]))
+
+    # Connect rooms linearly first
+    for i in range(room_count - 1):
+        rooms[i].exits.append(i + 1)
+        rooms[i + 1].exits.append(i)
+
+    # Add a few random extra connections for branching paths
+    for i in range(room_count):
+        if random.random() < 0.3:
+            other = random.randint(0, room_count - 1)
+            if other != i and other not in rooms[i].exits:
+                rooms[i].exits.append(other)
+                rooms[other].exits.append(i)
+    return rooms
+
+
+def explore_dungeon(player: Player, choose_action: Optional[Callable] = None) -> str:
     """Run a short procedural dungeon and return the result message."""
+
     if player.energy < 10:
         return "Too tired to explore!"
-    enemies = generate_dungeon()
-    for enemy in enemies:
-        result = fight_custom_enemy(player, enemy)
-        if "lost" in result:
-            return "You were defeated in the dungeon!"
-    loot = random.choice(DUNGEON_LOOT)
-    player.inventory.append(loot)
-    return f"Dungeon cleared! You found {loot.name}"
+
+    dungeon = generate_dungeon()
+    current = 0
+    visited = set()
+
+    def auto_choice(kind, options=None):
+        if kind == "trap":
+            return "disarm"
+        if kind == "enemy":
+            return "fight"
+        if kind == "exit":
+            for ex in options:
+                if ex not in visited:
+                    return ex
+            return options[0] if options else None
+
+    if choose_action is None:
+        choose_action = auto_choice
+
+    while True:
+        room = dungeon[current]
+        visited.add(current)
+
+        # Handle traps or puzzles
+        if room.trap:
+            action = choose_action("trap", room)
+            if action == "disarm":
+                chance = min(0.9, 0.5 + player.speed * 0.05)
+                if random.random() <= chance:
+                    if not room.enemies:
+                        reward = random.choice(TRAP_LOOT)
+                        player.inventory.append(reward)
+                else:
+                    player.health -= 5
+                    if player.health <= 0:
+                        return "You were defeated in the dungeon!"
+            else:
+                player.health -= 5
+                if player.health <= 0:
+                    return "You were defeated in the dungeon!"
+
+        # Combat encounters
+        for enemy in room.enemies:
+            action = choose_action("enemy", enemy)
+            if action == "flee" and random.random() < 0.5:
+                continue
+            result = fight_custom_enemy(player, enemy)
+            if "lost" in result:
+                return "You were defeated in the dungeon!"
+
+        # Check for completion
+        if current == len(dungeon) - 1:
+            loot = random.choice(DUNGEON_LOOT)
+            player.inventory.append(loot)
+            return f"Dungeon cleared! You found {loot.name}"
+
+        # Choose next room
+        next_room = choose_action("exit", room.exits)
+        if next_room is None:
+            loot = random.choice(DUNGEON_LOOT)
+            player.inventory.append(loot)
+            return f"Dungeon cleared! You found {loot.name}"
+        current = next_room

--- a/rendering.py
+++ b/rendering.py
@@ -46,6 +46,8 @@ CLOUDS = []
 RAINDROPS = []
 SNOWFLAKES = []
 CITY_MAP = None
+DUNGEON_TRAP_IMAGE = None
+DUNGEON_PUZZLE_IMAGE = None
 
 
 def load_player_sprites(color=None):
@@ -155,6 +157,60 @@ def draw_quest_marker(surface, player_rect, target_rect, cam_x, cam_y):
         y + 8 * math.sin(angle - math.pi * 0.75),
     )
     pygame.draw.polygon(surface, (255, 50, 50), [tip, left, right])
+
+
+def load_dungeon_assets():
+    """Load simple images for traps and puzzles in the dungeon."""
+    global DUNGEON_TRAP_IMAGE, DUNGEON_PUZZLE_IMAGE
+    if DUNGEON_TRAP_IMAGE and DUNGEON_PUZZLE_IMAGE:
+        return
+
+    trap_path = os.path.join(settings.IMAGE_DIR, "trap.png")
+    puzzle_path = os.path.join(settings.IMAGE_DIR, "puzzle.png")
+
+    if os.path.exists(trap_path):
+        DUNGEON_TRAP_IMAGE = pygame.image.load(trap_path).convert_alpha()
+    else:
+        DUNGEON_TRAP_IMAGE = pygame.Surface((20, 20), pygame.SRCALPHA)
+        pygame.draw.polygon(
+            DUNGEON_TRAP_IMAGE, (200, 0, 0), [(10, 0), (20, 20), (0, 20)]
+        )
+
+    if os.path.exists(puzzle_path):
+        DUNGEON_PUZZLE_IMAGE = pygame.image.load(puzzle_path).convert_alpha()
+    else:
+        DUNGEON_PUZZLE_IMAGE = pygame.Surface((20, 20), pygame.SRCALPHA)
+        pygame.draw.rect(DUNGEON_PUZZLE_IMAGE, (0, 100, 200), (0, 0, 20, 20))
+        font = scaled_font(14)
+        q = font.render("?", True, (255, 255, 255))
+        DUNGEON_PUZZLE_IMAGE.blit(q, (5, 2))
+
+
+def draw_dungeon_room(surface, room, position, font=None):
+    """Visualize a dungeon room with traps, enemies, and exits."""
+    load_dungeon_assets()
+    x, y = position
+    pygame.draw.circle(surface, (180, 180, 180), (x, y), 30, 2)
+    if font is None:
+        font = scaled_font(14)
+
+    if room.trap:
+        img = (
+            DUNGEON_TRAP_IMAGE
+            if "trap" in room.trap
+            else DUNGEON_PUZZLE_IMAGE
+        )
+        surface.blit(img, (x - img.get_width() // 2, y - img.get_height() // 2))
+
+    if room.enemies:
+        txt = font.render(str(len(room.enemies)), True, (255, 0, 0))
+        surface.blit(txt, (x - txt.get_width() // 2, y - txt.get_height() // 2))
+
+    for i, _ in enumerate(room.exits):
+        angle = (i / max(1, len(room.exits))) * math.tau
+        ex_x = x + 35 * math.cos(angle)
+        ex_y = y + 35 * math.sin(angle)
+        pygame.draw.line(surface, (255, 255, 0), (x, y), (ex_x, ex_y), 2)
 
 
 def building_color(btype):

--- a/tests/test_dungeons.py
+++ b/tests/test_dungeons.py
@@ -1,8 +1,10 @@
 import random
+import random
 import pygame
 import settings
 from entities import Player
-from dungeons import explore_dungeon
+import dungeons
+from dungeons import explore_dungeon, Room
 
 
 def test_explore_dungeon_rewards_loot():
@@ -14,7 +16,8 @@ def test_explore_dungeon_rewards_loot():
     count = len(player.inventory)
     msg = explore_dungeon(player)
     assert "Dungeon cleared" in msg
-    assert len(player.inventory) == count + 1
+    # At least one reward should be granted
+    assert len(player.inventory) >= count + 1
 
 
 def test_explore_dungeon_tired():
@@ -22,3 +25,22 @@ def test_explore_dungeon_tired():
     player.energy = 5
     msg = explore_dungeon(player)
     assert msg == "Too tired to explore!"
+
+
+def test_trap_room_reward(monkeypatch):
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.energy = 100
+
+    def fake_gen():
+        return [
+            Room(enemies=[], trap="spike trap", exits=[1]),
+            Room(enemies=[], trap=None, exits=[]),
+        ]
+
+    monkeypatch.setattr(dungeons, "generate_dungeon", fake_gen)
+    monkeypatch.setattr(dungeons.random, "random", lambda: 0.0)
+    count = len(player.inventory)
+    msg = explore_dungeon(player)
+    assert "Dungeon cleared" in msg
+    # Trap loot plus final loot
+    assert len(player.inventory) == count + 2


### PR DESCRIPTION
## Summary
- Introduce `Room` structure with enemies, traps/puzzles and exits
- Generate connected dungeon graphs and handle traps, combat, and exits in exploration
- Visualize dungeon rooms, traps and branches via new rendering helpers

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a723f0f7e48325a8bcfb4457c23d1d