### PR TITLE
Add inventory sorting with UI indicator

### DIFF
--- a/game.py
+++ b/game.py
@@ -46,6 +46,7 @@ from inventory import (
     train_companion,
     upgrade_companion_ability,
     COMPANION_ABILITIES,
+    sort_inventory,
     plant_seed,
     harvest_crops,
     sell_produce,
@@ -318,6 +319,7 @@ def main():
         show_log = False
         show_help = False
         show_minimap = False
+        inventory_sort = ""
         dragging_item = None
         drag_rotation = 0
         shop_message = ""
@@ -343,6 +345,7 @@ def main():
         show_log = False
         show_help = False
         show_minimap = False
+        inventory_sort = ""
         dragging_item = None
         drag_rotation = 0
         shop_message = ""
@@ -503,6 +506,15 @@ def main():
                     shop_message_timer = 60
                 elif event.key == pygame.K_TAB:
                     show_minimap = not show_minimap
+                elif show_inventory and event.key == pygame.K_n:
+                    sort_inventory(player, "name")
+                    inventory_sort = "name"
+                elif show_inventory and event.key == pygame.K_t:
+                    sort_inventory(player, "type")
+                    inventory_sort = "type"
+                elif show_inventory and event.key == pygame.K_s:
+                    sort_inventory(player, "stat")
+                    inventory_sort = "stat"
                 elif (
                     event.key == pygame.K_h
                     and not show_inventory
@@ -1705,6 +1717,7 @@ def main():
                 slot_rects,
                 item_rects,
                 (dragging_item, drag_pos) if dragging_item else None,
+                inventory_sort,
                 hotkey_rects,
                 compute_furniture_rects(player) if inside_home else None,
             )

--- a/inventory.py
+++ b/inventory.py
@@ -285,6 +285,26 @@ def adopt_companion(player: Player, index: int) -> str:
     return f"Adopted {name}!"
 
 
+def sort_inventory(player: Player, key: str) -> None:
+    """Sort ``player.inventory`` in-place.
+
+    ``key`` can be ``"name"``, ``"type"``, or ``"stat"``.  Name sorts
+    alphabetically, type sorts by equipment slot then name, and stat sorts by
+    the combined attack/defense/speed values in descending order.
+    """
+
+    if key == "name":
+        player.inventory.sort(key=lambda i: i.name.lower())
+    elif key == "type":
+        player.inventory.sort(key=lambda i: (i.slot, i.name.lower()))
+    elif key == "stat":
+        player.inventory.sort(
+            key=lambda i: i.attack + i.defense + i.speed,
+            reverse=True,
+        )
+
+
+
 def plant_seed(player: Player, crop_type: Optional[str] = None) -> str:
     """Plant a seed of the given crop type if available."""
     # Determine crop if not specified: pick first seed available

--- a/rendering.py
+++ b/rendering.py
@@ -662,8 +662,21 @@ def draw_ui(surface, font, player, quests, story_quests=None):
 
 
 
-def draw_inventory_screen(surface, font, player, slot_rects, item_rects, dragging, hotkey_rects=None, furn_rects=None):
-    """Display the inventory screen with equipment and items."""
+def draw_inventory_screen(
+    surface,
+    font,
+    player,
+    slot_rects,
+    item_rects,
+    dragging,
+    sort_mode="",
+    hotkey_rects=None,
+    furn_rects=None,
+):
+    """Display the inventory screen with equipment and items.
+
+    ``sort_mode`` describes the active inventory sorting method.
+    """
     overlay = pygame.Surface((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT), pygame.SRCALPHA)
 
     overlay.fill((0, 0, 0, 160))
@@ -675,6 +688,9 @@ def draw_inventory_screen(surface, font, player, slot_rects, item_rects, draggin
 
     title = font.render("Inventory", True, FONT_COLOR)
     surface.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 70))
+    if sort_mode:
+        mode_txt = font.render(f"Sorted by: {sort_mode.title()}", True, FONT_COLOR)
+        surface.blit(mode_txt, (100, 110))
 
     for slot, rect in slot_rects.items():
         pygame.draw.rect(surface, (210, 210, 210), rect)

--- a/tests/test_inventory_sort.py
+++ b/tests/test_inventory_sort.py
@@ -1,0 +1,35 @@
+"""Tests for inventory sorting helper."""
+
+import pygame
+
+from entities import Player, InventoryItem
+import settings
+from inventory import sort_inventory
+
+
+def make_player():
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.inventory = [
+        InventoryItem("Sword", "weapon", attack=5),
+        InventoryItem("Apple", "consumable"),
+        InventoryItem("Bow", "weapon", attack=3, speed=1),
+    ]
+    return player
+
+
+def test_sort_by_name():
+    player = make_player()
+    sort_inventory(player, "name")
+    assert [i.name for i in player.inventory] == ["Apple", "Bow", "Sword"]
+
+
+def test_sort_by_type():
+    player = make_player()
+    sort_inventory(player, "type")
+    assert [i.name for i in player.inventory] == ["Apple", "Bow", "Sword"]
+
+
+def test_sort_by_stat():
+    player = make_player()
+    sort_inventory(player, "stat")
+    assert [i.name for i in player.inventory] == ["Sword", "Bow", "Apple"]


### PR DESCRIPTION
## Summary
- add `sort_inventory` helper for ordering items by name, type, or stats
- allow inventory screen to sort via `N`, `T`, and `S` keys
- display current sort mode on inventory screen

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc999a3f88325902a774bec468cd3