### PR TITLE
Add character customization for attire and accessories

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -19,6 +19,9 @@ class Player:
     name: str = "Player"
     color: Tuple[int, int, int] = settings.PLAYER_COLOR
     head_color: Tuple[int, int, int] = settings.PLAYER_HEAD_COLOR
+    pants_color: Tuple[int, int, int] = (50, 50, 150)
+    hat_color: Tuple[int, int, int] = (200, 200, 0)
+    has_hat: bool = False
     money: float = 50
     energy: float = 100
     health: float = 100

--- a/game.py
+++ b/game.py
@@ -329,12 +329,15 @@ def main():
         show_bus_menu = False
         bus_options = []
     else:
-        name, color, head_color = character_creation(screen, font)
+        name, color, head_color, pants_color, has_hat, hat_color = character_creation(screen, font)
         player = Player(
             pygame.Rect(MAP_WIDTH // 2, MAP_HEIGHT // 2, PLAYER_SIZE, PLAYER_SIZE),
             name=name,
             color=color,
             head_color=head_color,
+            pants_color=pants_color,
+            has_hat=has_hat,
+            hat_color=hat_color,
         )
         show_inventory = False
         show_perk_menu = False
@@ -377,12 +380,15 @@ def main():
         if loaded:
             self.player = loaded
         else:
-            name, color, head_color = character_creation(self.screen, self.font)
+            name, color, head_color, pants_color, has_hat, hat_color = character_creation(self.screen, self.font)
             self.player = Player(
                 pygame.Rect(MAP_WIDTH // 2, MAP_HEIGHT // 2, PLAYER_SIZE, PLAYER_SIZE),
                 name=name,
                 color=color,
                 head_color=head_color,
+                pants_color=pants_color,
+                has_hat=has_hat,
+                hat_color=hat_color,
             )
 
 
@@ -1678,6 +1684,9 @@ def main():
             player.facing_left,
             player.color,
             player.head_color,
+            player.pants_color,
+            player.has_hat,
+            player.hat_color,
         )
 
         target_building = quest_target_building(player, BUILDINGS)

--- a/helpers.py
+++ b/helpers.py
@@ -534,6 +534,9 @@ def save_game(player: Player) -> None:
         "name": player.name,
         "color": list(player.color),
         "head_color": list(player.head_color),
+        "pants_color": list(player.pants_color),
+        "hat_color": list(player.hat_color),
+        "has_hat": player.has_hat,
         "money": player.money,
         "energy": player.energy,
         "health": player.health,
@@ -656,6 +659,9 @@ def load_game() -> Optional[Player]:
     player.name = data.get("name", player.name)
     player.color = tuple(data.get("color", list(player.color)))
     player.head_color = tuple(data.get("head_color", list(player.head_color)))
+    player.pants_color = tuple(data.get("pants_color", list(player.pants_color)))
+    player.hat_color = tuple(data.get("hat_color", list(player.hat_color)))
+    player.has_hat = data.get("has_hat", player.has_hat)
     player.money = data.get("money", player.money)
     player.energy = data.get("energy", player.energy)
     player.health = data.get("health", player.health)

--- a/menus.py
+++ b/menus.py
@@ -196,7 +196,7 @@ def draw_workshop_menu(surface: pygame.Surface, font: pygame.font.Font, player, 
 
 
 def character_creation(screen: pygame.Surface, font: pygame.font.Font):
-    """Prompt for name and colors."""
+    """Prompt for name and appearance options."""
     name = ""
     colors = [(40, 40, 40), (200, 50, 50), (50, 90, 200)]
     color_names = ["Black", "Red", "Blue"]
@@ -204,7 +204,10 @@ def character_creation(screen: pygame.Surface, font: pygame.font.Font):
     head_color_names = ["Light", "Tan", "Brown"]
     body_idx = 0
     head_idx = 0
-    selecting_head = False
+    pants_idx = 0
+    hat_idx = 0
+    has_hat = False
+    selecting = 0  # 0=body,1=head,2=pants,3=hat
     while True:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -212,21 +215,38 @@ def character_creation(screen: pygame.Surface, font: pygame.font.Font):
                 sys.exit()
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_RETURN:
-                    return (name or "Player"), colors[body_idx], head_colors[head_idx]
+                    return (
+                        name or "Player",
+                        colors[body_idx],
+                        head_colors[head_idx],
+                        colors[pants_idx],
+                        has_hat,
+                        colors[hat_idx],
+                    )
                 if event.key == pygame.K_BACKSPACE:
                     name = name[:-1]
                 elif event.key == pygame.K_TAB:
-                    selecting_head = not selecting_head
+                    selecting = (selecting + 1) % 4
                 elif event.key == pygame.K_LEFT:
-                    if selecting_head:
-                        head_idx = (head_idx - 1) % len(head_colors)
-                    else:
+                    if selecting == 0:
                         body_idx = (body_idx - 1) % len(colors)
+                    elif selecting == 1:
+                        head_idx = (head_idx - 1) % len(head_colors)
+                    elif selecting == 2:
+                        pants_idx = (pants_idx - 1) % len(colors)
+                    elif selecting == 3 and has_hat:
+                        hat_idx = (hat_idx - 1) % len(colors)
                 elif event.key == pygame.K_RIGHT:
-                    if selecting_head:
-                        head_idx = (head_idx + 1) % len(head_colors)
-                    else:
+                    if selecting == 0:
                         body_idx = (body_idx + 1) % len(colors)
+                    elif selecting == 1:
+                        head_idx = (head_idx + 1) % len(head_colors)
+                    elif selecting == 2:
+                        pants_idx = (pants_idx + 1) % len(colors)
+                    elif selecting == 3 and has_hat:
+                        hat_idx = (hat_idx + 1) % len(colors)
+                elif event.key == pygame.K_SPACE and selecting == 3:
+                    has_hat = not has_hat
                 elif event.unicode and event.unicode.isprintable() and len(name) < 12:
                     name += event.unicode
         screen.fill((0, 0, 0))
@@ -242,21 +262,39 @@ def character_creation(screen: pygame.Surface, font: pygame.font.Font):
             True,
             head_colors[head_idx],
         )
+        pants_txt = font.render(
+            f"Pants Color: {color_names[pants_idx]} (\u2190/\u2192)",
+            True,
+            colors[pants_idx],
+        )
+        hat_status = "On" if has_hat else "Off"
+        hat_color = colors[hat_idx]
+        hat_txt = font.render(
+            f"Hat: {hat_status} ({color_names[hat_idx]}) (Space)",
+            True,
+            hat_color if has_hat else (200, 200, 200),
+        )
         toggle_txt = font.render("Press TAB to switch", True, (230, 230, 230))
         confirm = font.render("Press Enter to Start", True, (230, 230, 230))
-        screen.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 240))
-        screen.blit(prompt, (settings.SCREEN_WIDTH // 2 - prompt.get_width() // 2, 280))
+        screen.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 220))
+        screen.blit(prompt, (settings.SCREEN_WIDTH // 2 - prompt.get_width() // 2, 260))
         screen.blit(
-            body_txt, (settings.SCREEN_WIDTH // 2 - body_txt.get_width() // 2, 320)
+            body_txt, (settings.SCREEN_WIDTH // 2 - body_txt.get_width() // 2, 300)
         )
         screen.blit(
-            head_txt, (settings.SCREEN_WIDTH // 2 - head_txt.get_width() // 2, 350)
+            head_txt, (settings.SCREEN_WIDTH // 2 - head_txt.get_width() // 2, 330)
         )
         screen.blit(
-            toggle_txt, (settings.SCREEN_WIDTH // 2 - toggle_txt.get_width() // 2, 380)
+            pants_txt, (settings.SCREEN_WIDTH // 2 - pants_txt.get_width() // 2, 360)
         )
         screen.blit(
-            confirm, (settings.SCREEN_WIDTH // 2 - confirm.get_width() // 2, 410)
+            hat_txt, (settings.SCREEN_WIDTH // 2 - hat_txt.get_width() // 2, 390)
+        )
+        screen.blit(
+            toggle_txt, (settings.SCREEN_WIDTH // 2 - toggle_txt.get_width() // 2, 420)
+        )
+        screen.blit(
+            confirm, (settings.SCREEN_WIDTH // 2 - confirm.get_width() // 2, 450)
         )
         pygame.display.flip()
         pygame.time.wait(20)

--- a/rendering.py
+++ b/rendering.py
@@ -81,11 +81,29 @@ def load_player_sprites(color=None):
 
 
 def draw_player_sprite(
-    surface, rect, frame=0, facing_left=False, color=None, head_color=None
+    surface,
+    rect,
+    frame=0,
+    facing_left=False,
+    color=None,
+    head_color=None,
+    pants_color=None,
+    has_hat=False,
+    hat_color=None,
 ):
     sprites = load_player_sprites(color)
     if not sprites:
-        return draw_player(surface, rect, frame, facing_left, color, head_color)
+        return draw_player(
+            surface,
+            rect,
+            frame,
+            facing_left,
+            color,
+            head_color,
+            pants_color,
+            has_hat,
+            hat_color,
+        )
     image = sprites[frame % len(sprites)]
     if facing_left:
         image = pygame.transform.flip(image, True, False)
@@ -96,9 +114,22 @@ def draw_player_sprite(
     surface.blit(shadow, (x + image.get_width() // 2 - 20, y + image.get_height() - 6))
 
     surface.blit(image, (x, y))
+    if has_hat:
+        pygame.draw.rect(surface, hat_color or color, (x + image.get_width() // 2 - 12, y - 6, 24, 4))
+        pygame.draw.rect(surface, hat_color or color, (x + image.get_width() // 2 - 8, y - 16, 16, 10))
 
 
-def draw_player(surface, rect, frame=0, facing_left=False, color=None, head_color=None):
+def draw_player(
+    surface,
+    rect,
+    frame=0,
+    facing_left=False,
+    color=None,
+    head_color=None,
+    pants_color=None,
+    has_hat=False,
+    hat_color=None,
+):
     """Fallback stick figure drawing if sprites fail to load."""
     x = rect.x + rect.width // 2
     y = rect.y + rect.height
@@ -109,6 +140,8 @@ def draw_player(surface, rect, frame=0, facing_left=False, color=None, head_colo
     swing = math.sin(frame / 6) * 7 if frame else 0
     color = color or PLAYER_COLOR
     head_color = head_color or PLAYER_HEAD_COLOR
+    pants_color = pants_color or color
+    hat_color = hat_color or color
     pygame.draw.circle(surface, head_color, (x, y - 24), 10)
     pygame.draw.circle(surface, color, (x, y - 24), 10, 2)
     pygame.draw.line(surface, color, (x, y - 14), (x, y), 3)
@@ -120,8 +153,15 @@ def draw_player(surface, rect, frame=0, facing_left=False, color=None, head_colo
     pygame.draw.line(
         surface, color, (x, y - 10), (x - arm_offset, y - 2 - int(swing)), 3
     )
-    pygame.draw.line(surface, color, (x, y), (x + leg_offset, y + 16 + int(swing)), 3)
-    pygame.draw.line(surface, color, (x, y), (x - leg_offset, y + 16 - int(swing)), 3)
+    pygame.draw.line(
+        surface, pants_color, (x, y), (x + leg_offset, y + 16 + int(swing)), 3
+    )
+    pygame.draw.line(
+        surface, pants_color, (x, y), (x - leg_offset, y + 16 - int(swing)), 3
+    )
+    if has_hat:
+        pygame.draw.rect(surface, hat_color, (x - 12, y - 36, 24, 4))
+        pygame.draw.rect(surface, hat_color, (x - 8, y - 46, 16, 10))
 
 
 def draw_npc(surface, npc, font, offset=(0, 0)):
@@ -970,7 +1010,15 @@ def draw_home_interior(surface, font, player, frame, bed_rect, door_rect, furn_r
             )
 
     draw_player_sprite(
-        surface, player.rect, frame, player.facing_left, player.color, player.head_color
+        surface,
+        player.rect,
+        frame,
+        player.facing_left,
+        player.color,
+        player.head_color,
+        player.pants_color,
+        player.has_hat,
+        player.hat_color,
     )
 
 
@@ -1003,7 +1051,15 @@ def draw_forest_area(surface, font, player, frame, enemy_rects, door_rect):
         surface.blit(img, rect)
 
     draw_player_sprite(
-        surface, player.rect, frame, player.facing_left, player.color, player.head_color
+        surface,
+        player.rect,
+        frame,
+        player.facing_left,
+        player.color,
+        player.head_color,
+        player.pants_color,
+        player.has_hat,
+        player.hat_color,
     )
 
 
@@ -1104,5 +1160,13 @@ def draw_bar_interior(
     pygame.draw.circle(surface, (220, 210, 120), (knob_x, door_rect.centery), knob_r)
 
     draw_player_sprite(
-        surface, player.rect, frame, player.facing_left, player.color, player.head_color
+        surface,
+        player.rect,
+        frame,
+        player.facing_left,
+        player.color,
+        player.head_color,
+        player.pants_color,
+        player.has_hat,
+        player.hat_color,
     )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -12,6 +12,9 @@ def test_save_and_load_game(tmp_path):
         player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
         player.name = "TestPlayer"
         player.money = 123
+        player.pants_color = (1, 2, 3)
+        player.has_hat = True
+        player.hat_color = (4, 5, 6)
         player.inventory.append(InventoryItem("Test Item", "weapon", attack=2))
 
         helpers.save_game(player)
@@ -21,6 +24,9 @@ def test_save_and_load_game(tmp_path):
         assert loaded is not None
         assert loaded.name == player.name
         assert loaded.money == player.money
+        assert loaded.pants_color == player.pants_color
+        assert loaded.has_hat == player.has_hat
+        assert loaded.hat_color == player.hat_color
         assert any(item.name == "Test Item" for item in loaded.inventory)
     finally:
         helpers.SAVE_FILE = old_path


### PR DESCRIPTION
## Summary
- Allow players to configure pants color and optional hat during character creation
- Save and load new customization attributes in persistence layer
- Render pants and hats on the player sprite and during gameplay

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb5a759008325814b14c8c09186a3