### PR TITLE
Refactor game loop with state manager

### DIFF
--- a/game.py
+++ b/game.py
@@ -8,13 +8,11 @@ import settings
 from entities import Player
 from helpers import recalc_layouts, scaled_font, load_game
 from loaders import load_buildings
-from menus import start_menu, character_creation, pause_menu
-from rendering import draw_player_sprite
+from menus import start_menu, character_creation
 from settings import (
     MAP_HEIGHT,
     MAP_WIDTH,
     PLAYER_SIZE,
-    MINUTES_PER_FRAME,
     MUSIC_FILE,
     STEP_SOUND_FILE,
     ENTER_SOUND_FILE,
@@ -22,6 +20,8 @@ from settings import (
     MUSIC_VOLUME,
     SFX_VOLUME,
 )
+from state_manager import StateManager
+from states import PlayState
 
 
 class Game:
@@ -94,34 +94,20 @@ class Game:
         self.running = True
         self.frame = 0
 
+        # Initialize state manager with the default gameplay state
+        self.state_manager = StateManager()
+        self.state_manager.change_state(PlayState(self))
+
     # ------------------------------------------------------------------
-    # Game loop sections
+    # Main game loop
     # ------------------------------------------------------------------
-    def handle_events(self) -> None:
-        """Process all pending pygame events."""
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                self.running = False
-            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-                self.player = pause_menu(self, self.player)
-
-    def update(self) -> None:
-        """Update game state for the current frame."""
-        self.frame += 1
-        self.player.time = (self.player.time + MINUTES_PER_FRAME) % 1440
-
-    def render(self) -> None:
-        """Render the current frame to the window."""
-        self.screen.fill((0, 0, 0))
-        draw_player_sprite(self.screen, self.player.rect, frame=self.frame)
-        pygame.display.flip()
-
     def run(self) -> None:
         """Run the main game loop."""
         while self.running:
-            self.handle_events()
-            self.update()
-            self.render()
+            events = pygame.event.get()
+            self.state_manager.handle_events(events)
+            self.state_manager.update()
+            self.state_manager.render(self.screen)
             self.clock.tick(60)
 
 

--- a/state_manager.py
+++ b/state_manager.py
@@ -1,0 +1,49 @@
+"""Simple state management for game screens."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class GameState:
+    """Base class for individual game states."""
+
+    def on_enter(self) -> None:  # pragma: no cover - default implementation
+        pass
+
+    def on_exit(self) -> None:  # pragma: no cover - default implementation
+        pass
+
+    def handle_events(self, events) -> None:  # pragma: no cover - default implementation
+        pass
+
+    def update(self) -> None:  # pragma: no cover - default implementation
+        pass
+
+    def render(self, screen) -> None:  # pragma: no cover - default implementation
+        pass
+
+
+class StateManager:
+    """Maintain and delegate to the active :class:`GameState`."""
+
+    def __init__(self) -> None:
+        self.state: Optional[GameState] = None
+
+    def change_state(self, new_state: GameState) -> None:
+        if self.state:
+            self.state.on_exit()
+        self.state = new_state
+        self.state.on_enter()
+
+    def handle_events(self, events) -> None:
+        if self.state:
+            self.state.handle_events(events)
+
+    def update(self) -> None:
+        if self.state:
+            self.state.update()
+
+    def render(self, screen) -> None:
+        if self.state:
+            self.state.render(screen)

--- a/states.py
+++ b/states.py
@@ -1,0 +1,63 @@
+"""Concrete game state implementations."""
+
+from __future__ import annotations
+
+import pygame
+
+from menus import pause_menu
+from rendering import draw_player_sprite
+from settings import MINUTES_PER_FRAME
+from state_manager import GameState
+
+
+class PlayState(GameState):
+    """Normal gameplay state."""
+
+    def __init__(self, game) -> None:
+        self.game = game
+
+    def on_enter(self) -> None:  # pragma: no cover - nothing special on enter
+        pass
+
+    def on_exit(self) -> None:  # pragma: no cover - nothing special on exit
+        pass
+
+    def handle_events(self, events) -> None:
+        for event in events:
+            if event.type == pygame.QUIT:
+                self.game.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                self.game.state_manager.change_state(PauseState(self.game))
+
+    def update(self) -> None:
+        self.game.frame += 1
+        self.game.player.time = (self.game.player.time + MINUTES_PER_FRAME) % 1440
+
+    def render(self, screen) -> None:
+        screen.fill((0, 0, 0))
+        draw_player_sprite(screen, self.game.player.rect, frame=self.game.frame)
+        pygame.display.flip()
+
+
+class PauseState(GameState):
+    """Temporary state that shows the pause menu."""
+
+    def __init__(self, game) -> None:
+        self.game = game
+
+    def on_enter(self) -> None:
+        # The pause menu is blocking; once it returns we go back to the play state
+        self.game.player = pause_menu(self.game, self.game.player)
+        self.game.state_manager.change_state(PlayState(self.game))
+
+    def on_exit(self) -> None:  # pragma: no cover - nothing to clean up
+        pass
+
+    def handle_events(self, events) -> None:  # pragma: no cover - never called
+        pass
+
+    def update(self) -> None:  # pragma: no cover - never called
+        pass
+
+    def render(self, screen) -> None:  # pragma: no cover - never called
+        pass


### PR DESCRIPTION
## Summary
- Introduce a simple `StateManager` and `GameState` base class
- Move gameplay logic to new `PlayState` and `PauseState`
- Refactor `Game` to delegate loop operations to the state manager

## Testing
- `pytest` *(fails: ModuleNotFoundError for core modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9b2fd9848325a288cec3bfa8c7a9