### PR TITLE
Add NPC pathfinding and movement system

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -229,6 +229,26 @@ class NPC:
     work: Optional[str] = None
     work_start: int = 9
     work_end: int = 17
+    # movement state
+    destination: Optional[Tuple[int, int]] = None
+    path: List[Tuple[int, int]] = field(default_factory=list)
+    speed: int = 4
+
+    def move(self) -> None:
+        """Advance the NPC along its path one step."""
+        if not self.path:
+            return
+        target_x, target_y = self.path[0]
+        if self.rect.x < target_x:
+            self.rect.x += min(self.speed, target_x - self.rect.x)
+        elif self.rect.x > target_x:
+            self.rect.x -= min(self.speed, self.rect.x - target_x)
+        if self.rect.y < target_y:
+            self.rect.y += min(self.speed, target_y - self.rect.y)
+        elif self.rect.y > target_y:
+            self.rect.y -= min(self.speed, self.rect.y - target_y)
+        if self.rect.x == target_x and self.rect.y == target_y:
+            self.path.pop(0)
 
 
 @dataclass

--- a/game.py
+++ b/game.py
@@ -9,6 +9,8 @@ from entities import Player
 from helpers import recalc_layouts, scaled_font, load_game
 from loaders import load_buildings
 from menus import start_menu, character_creation
+from quests import NPCS
+from types import SimpleNamespace
 from settings import (
     MAP_HEIGHT,
     MAP_WIDTH,
@@ -52,6 +54,13 @@ class Game:
         self.clock = pygame.time.Clock()
         self.font = scaled_font(28)
         self.buildings = load_buildings()
+        self.npcs = NPCS
+        self.tilemap = SimpleNamespace(
+            width=settings.MAP_WIDTH // 40,
+            height=settings.MAP_HEIGHT // 40,
+            tilewidth=40,
+            tileheight=40,
+        )
 
         # Load audio assets if possible
         self.step_sound = self.enter_sound = self.quest_sound = None

--- a/pathfinding.py
+++ b/pathfinding.py
@@ -1,0 +1,81 @@
+"""Simple A* pathfinding over TileMap tiles."""
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+import heapq
+
+from tilemap import TileMap
+
+
+Coord = Tuple[int, int]
+
+
+def _heuristic(a: Coord, b: Coord) -> int:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def _neighbors(tm: TileMap, node: Coord) -> List[Coord]:
+    x, y = node
+    res: List[Coord] = []
+    for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+        nx, ny = x + dx, y + dy
+        if 0 <= nx < tm.width and 0 <= ny < tm.height:
+            res.append((nx, ny))
+    return res
+
+
+def _reconstruct(came_from: dict, current: Coord) -> List[Coord]:
+    path = [current]
+    while current in came_from:
+        current = came_from[current]
+        path.append(current)
+    path.reverse()
+    return path
+
+
+def find_path(tile_map: TileMap, start: Coord, goal: Coord) -> List[Coord]:
+    """Find a path from start to goal using A*.
+
+    Parameters
+    ----------
+    tile_map: TileMap
+        Map defining the grid dimensions.
+    start, goal: Tuple[int, int]
+        Pixel coordinates for start and goal.
+
+    Returns
+    -------
+    List of pixel coordinate steps (excluding the starting position).
+    """
+
+    # Convert pixel coordinates to tile coordinates
+    start_tile = (start[0] // tile_map.tilewidth, start[1] // tile_map.tileheight)
+    goal_tile = (goal[0] // tile_map.tilewidth, goal[1] // tile_map.tileheight)
+
+    open_set: List[Tuple[int, Coord]] = []
+    heapq.heappush(open_set, (0, start_tile))
+    came_from: dict = {}
+    g_score = {start_tile: 0}
+    f_score = {start_tile: _heuristic(start_tile, goal_tile)}
+
+    visited = set()
+    while open_set:
+        _, current = heapq.heappop(open_set)
+        if current == goal_tile:
+            tiles = _reconstruct(came_from, current)
+            if tiles and tiles[0] == start_tile:
+                tiles = tiles[1:]
+            return [
+                (x * tile_map.tilewidth, y * tile_map.tileheight) for x, y in tiles
+            ]
+        if current in visited:
+            continue
+        visited.add(current)
+        for neighbor in _neighbors(tile_map, current):
+            tentative_g = g_score[current] + 1
+            if tentative_g < g_score.get(neighbor, float("inf")):
+                came_from[neighbor] = current
+                g_score[neighbor] = tentative_g
+                f_score[neighbor] = tentative_g + _heuristic(neighbor, goal_tile)
+                heapq.heappush(open_set, (f_score[neighbor], neighbor))
+    return []

--- a/rendering.py
+++ b/rendering.py
@@ -165,7 +165,7 @@ def draw_player(
 
 
 def draw_npc(surface, npc, font, offset=(0, 0)):
-    """Draw an NPC with optional speech bubble."""
+    """Draw an NPC using its current position and optional speech bubble."""
     rect = npc.rect.move(offset)
     pygame.draw.rect(surface, (60, 120, 220), rect)
     if npc.bubble_timer > 0 and npc.bubble_message:

--- a/states.py
+++ b/states.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import pygame
 
 from menus import pause_menu
-from rendering import draw_player_sprite
+from rendering import draw_player_sprite, draw_npc
 from settings import MINUTES_PER_FRAME
 from state_manager import GameState
+from pathfinding import find_path
+from entities import Player, NPC, Building
+from tilemap import TileMap
+from typing import List
 
 
 class PlayState(GameState):
@@ -32,11 +36,48 @@ class PlayState(GameState):
     def update(self) -> None:
         self.game.frame += 1
         self.game.player.time = (self.game.player.time + MINUTES_PER_FRAME) % 1440
+        update_npcs(
+            self.game.player,
+            self.game.npcs,
+            self.game.buildings,
+            self.game.tilemap,
+        )
 
     def render(self, screen) -> None:
         screen.fill((0, 0, 0))
+        for npc in self.game.npcs:
+            draw_npc(screen, npc, self.game.font)
         draw_player_sprite(screen, self.game.player.rect, frame=self.game.frame)
         pygame.display.flip()
+
+
+def update_npcs(
+    player: Player,
+    npcs: List[NPC],
+    buildings: List[Building],
+    tile_map: TileMap,
+) -> None:
+    """Update NPC destinations and advance their movement."""
+    hour = int(player.time) // 60
+    for npc in npcs:
+        target = npc.home
+        if npc.work and npc.work_start <= hour < npc.work_end:
+            target = npc.work
+        building = next((b for b in buildings if b.btype == target), None)
+        if building:
+            dest = (
+                building.rect.centerx - npc.rect.width // 2,
+                building.rect.centery - npc.rect.height // 2,
+            )
+            if npc.destination != dest:
+                npc.destination = dest
+                npc.path = find_path(tile_map, npc.rect.topleft, dest)
+        npc.move()
+        if npc.bubble_timer > 0:
+            npc.bubble_timer -= 1
+        if npc.rect.colliderect(player.rect.inflate(40, 40)):
+            npc.bubble_message = f"Hi {player.name}"
+            npc.bubble_timer = 60
 
 
 class PauseState(GameState):


### PR DESCRIPTION
## Summary
- implement A* grid pathfinding helper
- extend NPCs with destinations, paths, and movement
- update PlayState to move NPCs and render them in the world

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c181c32b008325a110af0a0f31bdef