### PR TITLE
Add deck system and booster packs to card game

### DIFF
--- a/cardgame.py
+++ b/cardgame.py
@@ -1,47 +1,121 @@
-"""Simple trading card duel mini-game."""
+"""Simple trading card duel mini-game with deck support."""
 
 from __future__ import annotations
+
 import random
-from typing import List
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from entities import Player
 from quests import CARD_NAMES
 
-# Extra rare cards that can only be obtained from duels
+# Extra rare cards that can only be obtained from duels or boosters
 RARE_CARDS: List[str] = ["Phoenix", "Golem"]
 
 
-def _card_power(name: str) -> int:
-    """Return a basic power score for a card name."""
-    if name in CARD_NAMES:
-        return CARD_NAMES.index(name) + 1
-    if name in RARE_CARDS:
-        return len(CARD_NAMES) + RARE_CARDS.index(name) + 2
-    return 1
+@dataclass
+class Card:
+    """Basic card data used during duels."""
+
+    name: str
+    attack: int
+    defense: int = 0
+    effect: Optional[str] = None
+
+
+CARD_DATA = {name: {"attack": i + 1, "defense": (i + 1) // 2} for i, name in enumerate(CARD_NAMES)}
+for i, name in enumerate(RARE_CARDS, start=len(CARD_NAMES) + 1):
+    CARD_DATA[name] = {"attack": i + 1, "defense": (i + 1) // 2}
+
+
+def _make_card(name: str) -> Card:
+    data = CARD_DATA.get(name, {"attack": 1, "defense": 0})
+    return Card(name, data["attack"], data.get("defense", 0), data.get("effect"))
+
+
+@dataclass
+class Deck:
+    """A deck containing up to 30 cards with draw and discard piles."""
+
+    names: List[str]
+    draw_pile: List[Card] = field(init=False)
+    discard_pile: List[Card] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        limited = self.names[:30]
+        self.draw_pile = [_make_card(n) for n in limited]
+        random.shuffle(self.draw_pile)
+
+    def draw(self) -> Optional[Card]:
+        if not self.draw_pile:
+            if not self.discard_pile:
+                return None
+            self.draw_pile = self.discard_pile
+            self.discard_pile = []
+            random.shuffle(self.draw_pile)
+        return self.draw_pile.pop()
+
+    def discard(self, card: Card) -> None:
+        self.discard_pile.append(card)
+
+    def add(self, name: str) -> None:
+        if len(self.draw_pile) + len(self.discard_pile) >= 30:
+            return
+        card = _make_card(name)
+        self.draw_pile.append(card)
+
+
+def open_booster_pack(player: Player, count: int = 3) -> List[str]:
+    """Add ``count`` random cards to the player's collection."""
+
+    pool = CARD_NAMES + RARE_CARDS
+    rewards: List[str] = []
+    for _ in range(count):
+        name = random.choice(pool)
+        player.cards.append(name)
+        rewards.append(name)
+    return rewards
 
 
 def card_duel(player: Player) -> str:
-    """Duel an NPC using random cards."""
+    """Duel an NPC using a turn-based match loop."""
+
     if player.energy < 5:
         return "Too tired to duel!"
     player.energy -= 5
 
-    npc_cards = random.sample(CARD_NAMES, k=3)
-    deck = player.cards if player.cards else CARD_NAMES
-    player_cards = random.sample(deck, k=3)
+    player_names = player.deck or player.cards or CARD_NAMES
+    npc_names = random.sample(CARD_NAMES, k=min(30, len(CARD_NAMES)))
 
-    player_score = sum(_card_power(c) for c in player_cards)
-    npc_score = sum(_card_power(c) for c in npc_cards)
+    p_deck = Deck(player_names)
+    n_deck = Deck(npc_names)
 
-    if player_score >= npc_score:
+    p_hand = [p_deck.draw() for _ in range(5)]
+    n_hand = [n_deck.draw() for _ in range(5)]
+
+    p_health = 20
+    n_health = 20
+
+    while p_health > 0 and n_health > 0 and (p_hand or p_deck.draw_pile) and (
+        n_hand or n_deck.draw_pile
+    ):
+        p_card = p_hand.pop(0) if p_hand else p_deck.draw()
+        n_card = n_hand.pop(0) if n_hand else n_deck.draw()
+        if not p_card or not n_card:
+            break
+        n_damage = max(p_card.attack - n_card.defense, 0)
+        p_damage = max(n_card.attack - p_card.defense, 0)
+        n_health -= n_damage
+        p_health -= p_damage
+        p_deck.discard(p_card)
+        n_deck.discard(n_card)
+        if draw := p_deck.draw():
+            p_hand.append(draw)
+        if draw := n_deck.draw():
+            n_hand.append(draw)
+
+    if p_health > n_health:
         player.card_duels_won += 1
-        pool = [c for c in CARD_NAMES if c not in player.cards]
-        if not pool and random.random() < 0.3:
-            pool = [c for c in RARE_CARDS if c not in player.cards]
-        if pool:
-            reward = random.choice(pool)
-            player.cards.append(reward)
-            return f"You won the duel and got {reward}!"
-        return "You won the duel!"
-
+        reward = open_booster_pack(player, 1)[0]
+        return f"You won the duel and got {reward}!"
     return "You lost the duel."

--- a/entities.py
+++ b/entities.py
@@ -141,6 +141,8 @@ class Player:
 
     # Collection of discovered trading cards
     cards: List[str] = field(default_factory=list)
+    # Active deck used for card duels (up to 30 card names)
+    deck: List[str] = field(default_factory=list)
 
     # Current honorific title earned through achievements
     epithet: str = ""

--- a/inventory.py
+++ b/inventory.py
@@ -81,6 +81,11 @@ SHOP_ITEMS: List[Tuple[str, int, any]] = [
             InventoryItem("Crossbow", "weapon", attack=4, combo=2, weapon_type="ranged")
         ),
     ),
+    (
+        "Booster Pack",
+        15,
+        lambda p: __import__('cardgame').open_booster_pack(p),
+    ),
 ]
 
 # Loaded crop data

--- a/menus.py
+++ b/menus.py
@@ -96,6 +96,54 @@ def controls_menu(
         pygame.time.wait(20)
 
 
+def deck_build_menu(
+    game: "Game", player, screen: pygame.Surface | None = None, font: pygame.font.Font | None = None
+) -> None:
+    """Simple deck building interface to assemble up to 30 cards.
+
+    Uses arrow keys to navigate the player's card collection and Enter to add
+    cards to the active deck.  Backspace removes the last added card.  Esc exits
+    the menu saving the current deck selection.
+    """
+
+    screen = screen or game.screen
+    font = font or game.font
+    available = player.cards
+    deck = list(player.deck)
+    idx = 0
+
+    while True:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    player.deck = deck
+                    return
+                if event.key == pygame.K_UP:
+                    idx = (idx - 1) % len(available) if available else 0
+                elif event.key == pygame.K_DOWN:
+                    idx = (idx + 1) % len(available) if available else 0
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    if len(deck) < 30 and available:
+                        deck.append(available[idx])
+                elif event.key == pygame.K_BACKSPACE and deck:
+                    deck.pop()
+
+        screen.fill((0, 0, 0))
+        title = font.render("Deck Builder", True, (255, 255, 255))
+        screen.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 60))
+        for i, name in enumerate(available):
+            color = (255, 255, 0) if i == idx else (200, 200, 200)
+            txt = font.render(name, True, color)
+            screen.blit(txt, (100, 120 + i * 30))
+        deck_txt = font.render(f"Deck: {len(deck)}/30", True, (200, 200, 200))
+        screen.blit(deck_txt, (settings.SCREEN_WIDTH - deck_txt.get_width() - 20, 80))
+        pygame.display.flip()
+        pygame.time.wait(20)
+
+
 def pause_menu(
     game: "Game", player, screen: pygame.Surface | None = None, font: pygame.font.Font | None = None
 ):

--- a/tests/test_cardgame.py
+++ b/tests/test_cardgame.py
@@ -8,9 +8,12 @@ from unittest.mock import patch
 def test_card_duel_win_reward():
     player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
     player.energy = 50
-    with patch('random.sample', side_effect=[["Slime", "Goblin", "Farmer"], ["Dragon", "Wizard", "Alien"]]):
-        with patch('random.choice', return_value="Robot"):
-            msg = card_duel(player)
+    player.cards = ["Alien"] * 30
+    player.deck = player.cards[:30]
+    with patch('random.sample', lambda seq, k: ['Slime'] * k):
+        with patch('random.shuffle', lambda x: None):
+            with patch('random.choice', return_value="Robot"):
+                msg = card_duel(player)
     assert msg.startswith("You won")
     assert player.card_duels_won == 1
     assert "Robot" in player.cards


### PR DESCRIPTION
## Summary
- Introduce card `Deck` with draw and discard piles plus card metadata
- Replace `card_duel` with turn-based loop using decks and booster pack rewards
- Add deck-building menu and booster packs sold in shops

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c8dd38dc8325b77bb0ba8f5b13ee