### PR TITLE
Add business management menu and random events

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -342,9 +342,10 @@ def sleep(player: Player) -> Optional[str]:
     if "Arcade Room" in player.home_upgrades and random.random() < 0.3:
         player.tokens += 1
         messages.append("Won a token in your arcade")
-    profits = collect_profits(player)
+    profits, events = collect_profits(player)
     if profits:
         messages.append(f"Your businesses earned ${profits}")
+    messages.extend(events)
     if interest:
         messages.append(f"Earned ${interest} interest")
     return " ".join(messages) if messages else None

--- a/states.py
+++ b/states.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pygame
 
-from menus import pause_menu
+from menus import pause_menu, business_menu
 from rendering import draw_player_sprite, draw_npc
 from settings import MINUTES_PER_FRAME
 from state_manager import GameState
@@ -32,6 +32,12 @@ class PlayState(GameState):
                 self.game.running = False
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
                 self.game.state_manager.change_state(PauseState(self.game))
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_e:
+                for b in self.game.buildings:
+                    if b.rect.colliderect(self.game.player.rect):
+                        if b.btype == "business":
+                            business_menu(self.game, self.game.player)
+                        break
 
     def update(self) -> None:
         self.game.frame += 1

--- a/tests/test_business_events.py
+++ b/tests/test_business_events.py
@@ -1,0 +1,43 @@
+import random
+import pygame
+from businesses import BUSINESS_CATALOG, buy_business, collect_profits
+from entities import Player
+
+
+def make_player():
+    return Player(pygame.Rect(0, 0, 1, 1))
+
+
+def test_random_event_positive():
+    p = make_player()
+    p.money = 1000
+    stall_index = BUSINESS_CATALOG.index("Stall")
+    buy_business(p, stall_index)
+    # avoid robbery then trigger boom
+    orig_random = random.random
+    seq = iter([1.0, 0.15])
+    random.random = lambda: next(seq)
+    try:
+        profit, events = collect_profits(p)
+    finally:
+        random.random = orig_random
+    assert profit == 25 + 2 + 50  # base + charisma + boom bonus
+    assert any("boom" in msg.lower() for msg in events)
+    assert p.reputation["business"] > 0
+
+
+def test_random_event_negative():
+    p = make_player()
+    p.money = 1000
+    stall_index = BUSINESS_CATALOG.index("Stall")
+    buy_business(p, stall_index)
+    orig_random = random.random
+    seq = iter([1.0, 0.05])  # avoid robbery then inspection
+    random.random = lambda: next(seq)
+    try:
+        profit, events = collect_profits(p)
+    finally:
+        random.random = orig_random
+    assert profit == 25 + 2 - 20  # base + charisma - inspection fine
+    assert any("inspection" in msg.lower() for msg in events)
+    assert p.reputation["business"] < 0

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -39,7 +39,7 @@ def test_staff_affects_profits():
     orig_random = random.random
     random.random = lambda: 1.0  # avoid robbery
     try:
-        profit = collect_profits(p)
+        profit, _ = collect_profits(p)
     finally:
         random.random = orig_random
 
@@ -57,7 +57,7 @@ def test_robbery_zeroes_profit():
     orig_random = random.random
     random.random = lambda: 0.0  # force robbery
     try:
-        profit = collect_profits(p)
+        profit, _ = collect_profits(p)
     finally:
         random.random = orig_random
 
@@ -78,7 +78,7 @@ def test_marketing_campaign_boosts_profit():
     orig_random = random.random
     random.random = lambda: 1.0
     try:
-        profit = collect_profits(p)
+        profit, _ = collect_profits(p)
     finally:
         random.random = orig_random
     data = BUSINESS_DATA["Store"]
@@ -94,7 +94,7 @@ def test_train_staff_reduces_robbery_risk():
     orig_random = random.random
     random.random = lambda: 0.05
     try:
-        profit = collect_profits(p)
+        profit, _ = collect_profits(p)
     finally:
         random.random = orig_random
     assert profit == 0
@@ -106,7 +106,7 @@ def test_train_staff_reduces_robbery_risk():
         random.randint = orig_randint
     random.random = lambda: 0.05
     try:
-        profit_after = collect_profits(p)
+        profit_after, _ = collect_profits(p)
     finally:
         random.random = orig_random
     assert profit_after > 0


### PR DESCRIPTION
## Summary
- Implement random business events influencing profits and reputation
- Add interactive business management menu and hook to buildings
- Extend daily sleep logic to surface business event messages
- Introduce tests for positive and negative business events

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cb64bd0c8325b145c44fdf1a4d5b