### PR TITLE
Add weekday tracking and weekly events

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -26,6 +26,7 @@ class Player:
     energy: float = 100
     health: float = 100
     day: int = 1
+    weekday: int = 0  # 0=Monday
 
     time: float = 8 * 60  # minutes in the day
     strength: int = 1

--- a/rendering.py
+++ b/rendering.py
@@ -36,7 +36,7 @@ from tilemap import TileMap
 from careers import get_job_title, job_progress
 from inventory import crafting_exp_needed, CROPS
 from constants import PERK_MAX_LEVEL
-from helpers import scaled_font
+from helpers import scaled_font, WEEKDAY_NAMES
 from quests import SIDE_QUESTS, COMPANION_QUESTS
 import factions
 
@@ -645,7 +645,11 @@ def draw_ui(surface, font, player, quests, story_quests=None):
         craft_prog = "No Crafting"
     craft_txt = font.render(f"Craft XP: {craft_prog}", True, FONT_COLOR)
     bar.blit(craft_txt, (settings.SCREEN_WIDTH - craft_txt.get_width() - 20, 32))
-    season_txt = font.render(f"{player.season} - {player.weather}", True, FONT_COLOR)
+    season_txt = font.render(
+        f"{WEEKDAY_NAMES[player.weekday]} - {player.season} - {player.weather}",
+        True,
+        FONT_COLOR,
+    )
     bar.blit(season_txt, (settings.SCREEN_WIDTH // 2 - season_txt.get_width() // 2, 32))
     if player.companion:
         ctxt = font.render(f"Pet: {player.companion}", True, FONT_COLOR)


### PR DESCRIPTION
## Summary
- track current weekday in `Player`
- run weekly events and update HUD to show weekday
- support weekend hours for building availability

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'businesses')*


------
https://chatgpt.com/codex/tasks/task_e_68c7fb9a7ec483258bc50f4f346e99ea