### PR TITLE
Introduce business futures trading for businesses

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -104,6 +104,10 @@ class Player:
     business_reputation: Dict[str, int] = field(default_factory=dict)
     # Temporary staff skill training to reduce robberies
     business_skill: Dict[str, int] = field(default_factory=dict)
+    # Speculative futures contracts keyed by business name
+    business_futures: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # Narrative log of resolved futures deals
+    business_future_log: List[str] = field(default_factory=list)
 
     # Tracks per-NPC interaction states
     npc_progress: Dict[str, int] = field(default_factory=dict)

--- a/menus.py
+++ b/menus.py
@@ -14,7 +14,9 @@ from businesses import (
     manage_business,
     hire_staff,
     run_marketing_campaign,
+    schedule_future_contract,
     train_staff,
+    cash_out_future,
 )
 from quests import LEADERBOARD_FILE
 import settings
@@ -201,6 +203,12 @@ def business_menu(
                     message = run_marketing_campaign(player, names[idx])
                 elif event.key == pygame.K_t:
                     message = train_staff(player, names[idx])
+                elif event.key == pygame.K_f:
+                    name = names[idx]
+                    if name in player.business_futures:
+                        message = cash_out_future(player, name)
+                    else:
+                        message = schedule_future_contract(player, name)
 
         screen.fill((0, 0, 0))
         title = font.render("Businesses", True, (255, 255, 255))
@@ -208,13 +216,23 @@ def business_menu(
         for i, name in enumerate(names):
             staff = player.business_staff.get(name, 0)
             color = (255, 255, 0) if i == idx else (200, 200, 200)
-            txt = font.render(f"{name} (staff {staff})", True, color)
+            label = f"{name} (staff {staff})"
+            contract = player.business_futures.get(name)
+            if contract:
+                due = contract.get("day_due", player.day)
+                if player.day >= due:
+                    label += " [Future ready]"
+                else:
+                    label += f" [Future day {due}]"
+            txt = font.render(label, True, color)
             screen.blit(txt, (100, 120 + i * 40))
         if message:
             msg_txt = font.render(message, True, (200, 200, 200))
             screen.blit(msg_txt, (100, settings.SCREEN_HEIGHT - 80))
         info = font.render(
-            "M:Manage H:Hire C:Campaign T:Train Esc:Exit", True, (200, 200, 200)
+            "M:Manage H:Hire C:Campaign T:Train F:Futures Esc:Exit",
+            True,
+            (200, 200, 200),
         )
         screen.blit(info, (100, settings.SCREEN_HEIGHT - 40))
         pygame.display.flip()

--- a/tests/test_businesses.py
+++ b/tests/test_businesses.py
@@ -6,10 +6,12 @@ from businesses import (
     BUSINESS_CATALOG,
     BUSINESS_DATA,
     buy_business,
+    cash_out_future,
     upgrade_business,
     hire_staff,
     collect_profits,
     run_marketing_campaign,
+    schedule_future_contract,
     train_staff,
 )
 
@@ -110,4 +112,72 @@ def test_train_staff_reduces_robbery_risk():
     finally:
         random.random = orig_random
     assert profit_after > 0
+
+
+def test_schedule_and_cash_out_future_contract():
+    p = make_player()
+    p.money = 1000
+    stall_index = BUSINESS_CATALOG.index("Stall")
+    buy_business(p, stall_index)
+    p.charisma = 1
+    money_after_purchase = p.money
+
+    seq = iter([5, 2, 90])
+    orig_randint = random.randint
+    random.randint = lambda a, b: next(seq)
+    try:
+        message = schedule_future_contract(p, "Stall")
+    finally:
+        random.randint = orig_randint
+
+    assert "Margin" in message
+    assert "Stall" in p.business_futures
+    margin = max(50, int(BUSINESS_DATA["Stall"].base_profit * 0.6))
+    assert p.money == money_after_purchase - margin
+
+    # Cannot cash out before due date
+    early_message = cash_out_future(p, "Stall")
+    assert "matures" in early_message
+
+    contract = p.business_futures["Stall"]
+    p.day = contract["day_due"]
+    money_before = p.money
+    message = cash_out_future(p, "Stall")
+    assert "futures" in message
+    assert "Stall" not in p.business_futures
+    assert p.money == money_before + contract["payout"]
+    if contract["payout"] > 0 and contract["risk"] == "speculative":
+        assert p.reputation["business"] > 0
+
+
+def test_collect_profits_reconciles_due_futures():
+    p = make_player()
+    p.money = 0
+    p.businesses["Stall"] = BUSINESS_DATA["Stall"].base_profit
+    p.business_bonus["Stall"] = 0
+    p.business_staff["Stall"] = 0
+    p.business_reputation["Stall"] = 0
+    p.business_skill["Stall"] = 0
+    p.business_futures["Stall"] = {
+        "payout": 40,
+        "day_due": p.day,
+        "risk": "hedged",
+        "flavour": "Test hedge resolves.",
+        "reputation_bonus": 0,
+        "charisma_score": 0,
+        "margin": 0,
+    }
+
+    orig_random = random.random
+    random.random = lambda: 1.0
+    try:
+        profit, events = collect_profits(p)
+    finally:
+        random.random = orig_random
+
+    assert "Test hedge resolves." in events[0]
+    assert "Stall" not in p.business_futures
+    expected_profit = BUSINESS_DATA["Stall"].base_profit + p.charisma * 2
+    assert profit == expected_profit
+    assert p.money == 40 + expected_profit
 


### PR DESCRIPTION
## Summary
- add futures contract tracking to the player and implement scheduling/cash-out logic with flavour text and reputation hooks
- expose futures interactions in the business management menu and annotate listings with contract status
- settle due futures ahead of normal profit calculations and cover the flows with automated tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa7f698a08325bd936d449cab2c58