### PR TITLE
Add dream bazaar event and dream shard shop mechanics

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -45,6 +45,10 @@ class Player:
     dealer_exp: int = 0
     clinic_exp: int = 0
     tokens: int = 0
+    # Currency found within lucid dreams
+    dream_shards: int = 0
+    # Pending dream shop offers available after waking
+    pending_dream_shop: List[Dict[str, Any]] = field(default_factory=list)
     # Crafting skills and experience per skill
     crafting_skills: Dict[str, int] = field(default_factory=dict)
     crafting_exp: Dict[str, int] = field(default_factory=dict)

--- a/states/dream_state.py
+++ b/states/dream_state.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import random
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List, Any
 
 import pygame
 
 from . import PlayState
+from inventory import dream_shop_purchase
 
 
 class DreamState(PlayState):
@@ -19,6 +20,9 @@ class DreamState(PlayState):
         self.duration: int = int(event.get("duration", 180))
         self.elapsed = 0
         self.finished = False
+        inventory = event.get("shop_inventory")
+        self.shop_inventory: List[Dict[str, Any]] = inventory if isinstance(inventory, list) else []
+        self.message: str = ""
         self._particles = [
             (
                 random.random(),
@@ -37,12 +41,14 @@ class DreamState(PlayState):
         for event in events:
             if event.type == pygame.QUIT:
                 self.game.running = False
-            elif event.type == pygame.KEYDOWN and event.key in (
-                pygame.K_RETURN,
-                pygame.K_SPACE,
-                pygame.K_ESCAPE,
-            ):
-                self._return_to_play()
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_RETURN, pygame.K_SPACE, pygame.K_ESCAPE):
+                    self._return_to_play()
+                elif self.shop_inventory and pygame.K_1 <= event.key <= pygame.K_9:
+                    index = event.key - pygame.K_1
+                    self._attempt_purchase(index)
+                elif self.shop_inventory and event.key == pygame.K_0:
+                    self._return_to_play()
 
     def update(self) -> None:
         if self.finished:
@@ -76,10 +82,13 @@ class DreamState(PlayState):
                 self.event.get("title", "Dreamscape"),
                 "",
                 self.event.get("description", ""),
+                self.event.get("flavor", ""),
                 "",
                 self.event.get("summary", ""),
             ]
             self._draw_centered_lines(screen, lines, font)
+            if self.shop_inventory:
+                self._draw_shop(screen, font)
         pygame.display.flip()
 
     def _draw_centered_lines(self, screen, lines, font) -> None:
@@ -99,6 +108,40 @@ class DreamState(PlayState):
             rect = surface.get_rect(center=(screen.get_width() // 2, current_y + surface.get_height() // 2))
             screen.blit(surface, rect)
             current_y += surface.get_height() + spacing
+
+    def _draw_shop(self, screen, font) -> None:
+        base_x = int(screen.get_width() * 0.1)
+        base_y = int(screen.get_height() * 0.6)
+        line_height = font.get_height() + 6
+        shards_text = font.render(
+            f"Dream Shards: {self.game.player.dream_shards}", True, (255, 255, 200)
+        )
+        screen.blit(shards_text, (base_x, base_y))
+        base_y += line_height
+        for idx, offer in enumerate(self.shop_inventory):
+            name = str(offer.get("name", "Mystery"))
+            cost = int(offer.get("cost", 0))
+            purchased = offer.get("purchased", False)
+            status = " - Sold" if purchased else ""
+            label = f"{idx + 1}. {name} - {cost} shards{status}"
+            if purchased:
+                color = (120, 120, 120)
+            elif self.game.player.dream_shards < cost:
+                color = (220, 140, 140)
+            else:
+                color = (220, 220, 255)
+            screen.blit(font.render(label, True, color), (base_x, base_y))
+            base_y += line_height
+        instructions = "Press 1-9 to buy, Enter to wake"
+        screen.blit(font.render(instructions, True, (255, 255, 255)), (base_x, base_y))
+        if self.message:
+            base_y += line_height
+            screen.blit(font.render(self.message, True, (255, 230, 160)), (base_x, base_y))
+
+    def _attempt_purchase(self, index: int) -> None:
+        if not self.shop_inventory:
+            return
+        self.message = dream_shop_purchase(self.game.player, self.shop_inventory, index)
 
     def _return_to_play(self) -> None:
         if not self.finished:

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -2,7 +2,7 @@ import random
 import pygame
 import settings
 from entities import Player
-from inventory import get_shop_price, SHOP_ITEMS
+from inventory import get_shop_price, SHOP_ITEMS, dream_shop_purchase
 
 
 def make_player():
@@ -22,3 +22,45 @@ def test_shop_price_fluctuates():
     r = random.Random(player.day).random()
     expected = int(round(SHOP_ITEMS[0][1] * 1.2 * (0.8 + r * 0.4)))
     assert get_shop_price(player, 0) == expected
+
+
+def test_dream_shop_purchase_applies_effect_and_deducts_shards():
+    player = make_player()
+    player.dream_shards = 10
+    offers = [
+        {"name": "Focus Draught", "cost": 4, "effect": {"type": "stat", "stat": "intelligence", "amount": 2}},
+        {"name": "Charm Sigil", "cost": 3, "effect": "lucid_charm"},
+    ]
+
+    message = dream_shop_purchase(player, offers, 0)
+    assert message == "Bought Focus Draught"
+    assert player.dream_shards == 6
+    assert player.intelligence == 3
+    assert offers[0]["purchased"] is True
+
+    message = dream_shop_purchase(player, offers, 1)
+    assert message == "Bought Charm Sigil"
+    assert player.dream_shards == 3
+    assert player.charisma == 2
+    assert offers[1]["purchased"] is True
+
+
+def test_dream_shop_purchase_requires_shards_and_prevents_repeat():
+    player = make_player()
+    player.dream_shards = 3
+    offers = [{"name": "Token Fragment", "cost": 4, "effect": "lucid_token"}]
+
+    message = dream_shop_purchase(player, offers, 0)
+    assert message == "Not enough dream shards"
+    assert player.dream_shards == 3
+    assert "purchased" not in offers[0]
+
+    player.dream_shards = 5
+    message = dream_shop_purchase(player, offers, 0)
+    assert message == "Bought Token Fragment"
+    assert player.dream_shards == 1
+    assert offers[0]["purchased"] is True
+
+    message = dream_shop_purchase(player, offers, 0)
+    assert message == "Sold out"
+    assert player.dream_shards == 1


### PR DESCRIPTION
## Summary
- add dream shard currency tracking to the player and surface a lucid bazaar dream event that awards shards and offers shop inventory
- extend the dream state to show dream shop offers and route purchases through new inventory helpers that spend shards and apply effects
- cover dream shop purchases with economy tests to confirm shard deductions, gating, and effect triggers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d152bcedfc83258aef1237d8603277