### PR TITLE
Add companion errand scheduling and resolution

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -81,6 +81,8 @@ class Player:
     companion_morale: int = 100
     # Ability levels for each companion ability
     companion_abilities: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    # Pending errands companions will attempt after resting
+    companion_errands: List[Dict[str, Any]] = field(default_factory=list)
 
     home_upgrades: List[str] = field(default_factory=list)
     perk_points: int = 0

--- a/helpers.py
+++ b/helpers.py
@@ -24,6 +24,7 @@ from quests import (
 )
 from combat import energy_cost
 from businesses import collect_profits
+from inventory import resolve_companion_errands
 import settings
 
 
@@ -467,6 +468,8 @@ def sleep(player: Player) -> Optional[str]:
     messages.extend(events)
     if interest:
         messages.append(f"Earned ${interest} interest")
+    if player.companion_errands:
+        messages.extend(resolve_companion_errands(player))
     return " ".join(messages) if messages else None
 
 

--- a/menus.py
+++ b/menus.py
@@ -20,7 +20,14 @@ from businesses import (
 )
 from quests import LEADERBOARD_FILE
 import settings
-from inventory import crafting_exp_needed
+from inventory import (
+    SHOP_ITEMS,
+    COMPANION_ERRAND_FEE,
+    MIN_COMPANION_MORALE_FOR_ERRAND,
+    crafting_exp_needed,
+    schedule_companion_errand,
+    companion_errand_success_chance,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from game import Game
@@ -235,6 +242,68 @@ def business_menu(
             (200, 200, 200),
         )
         screen.blit(info, (100, settings.SCREEN_HEIGHT - 40))
+        pygame.display.flip()
+        pygame.time.wait(20)
+
+
+def pet_shop_menu(
+    game: "Game", player, screen: pygame.Surface | None = None, font: pygame.font.Font | None = None
+) -> None:
+    """Allow the player to schedule companion errands at the Pet Shop."""
+
+    screen = screen or game.screen
+    font = font or game.font
+    if not SHOP_ITEMS:
+        return
+
+    idx = 0
+    message = ""
+
+    while True:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    return
+                if event.key == pygame.K_UP:
+                    idx = (idx - 1) % len(SHOP_ITEMS)
+                elif event.key == pygame.K_DOWN:
+                    idx = (idx + 1) % len(SHOP_ITEMS)
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    message = schedule_companion_errand(player, idx)
+
+        screen.fill((0, 0, 0))
+        title = font.render("Pet Shop Errands", True, (255, 255, 255))
+        screen.blit(title, (settings.SCREEN_WIDTH // 2 - title.get_width() // 2, 60))
+
+        chance = companion_errand_success_chance(player)
+        chance_txt = font.render(
+            f"Success chance: {int(chance * 100)}%", True, (200, 200, 200)
+        )
+        screen.blit(chance_txt, (100, 110))
+        fee_txt = font.render(
+            f"Fee: ${COMPANION_ERRAND_FEE}  Morale needed: {MIN_COMPANION_MORALE_FOR_ERRAND}",
+            True,
+            (200, 200, 200),
+        )
+        screen.blit(fee_txt, (100, 140))
+
+        max_visible = 12
+        start = max(0, min(len(SHOP_ITEMS) - max_visible, idx - max_visible // 2))
+        for i in range(start, min(len(SHOP_ITEMS), start + max_visible)):
+            item_name = SHOP_ITEMS[i][0]
+            color = (255, 255, 0) if i == idx else (200, 200, 200)
+            txt = font.render(f"{i + 1}. {item_name}", True, color)
+            screen.blit(txt, (100, 180 + (i - start) * 30))
+
+        info = font.render("Enter to schedule, Esc to exit", True, (200, 200, 200))
+        screen.blit(info, (100, settings.SCREEN_HEIGHT - 80))
+        if message:
+            msg_txt = font.render(message, True, (180, 220, 180))
+            screen.blit(msg_txt, (100, settings.SCREEN_HEIGHT - 120))
+
         pygame.display.flip()
         pygame.time.wait(20)
 

--- a/states/__init__.py
+++ b/states/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pygame
 import settings
 
-from menus import pause_menu, business_menu
+from menus import pause_menu, business_menu, pet_shop_menu
 from rendering import (
     draw_player_sprite,
     draw_npc,
@@ -72,6 +72,8 @@ class PlayState(GameState):
                                         self.game.enter_sound.play()
                                     except Exception:
                                         pass
+                        elif b.btype == "petshop":
+                            pet_shop_menu(self.game, self.game.player)
                         break
 
     def update(self) -> None:

--- a/tests/test_inventory_errands.py
+++ b/tests/test_inventory_errands.py
@@ -1,0 +1,85 @@
+import pygame
+import settings
+import inventory
+from entities import Player
+from inventory import (
+    COMPANION_ERRAND_FEE,
+    schedule_companion_errand,
+    resolve_companion_errands,
+)
+
+
+def make_player() -> Player:
+    player = Player(pygame.Rect(0, 0, settings.PLAYER_SIZE, settings.PLAYER_SIZE))
+    player.money = 100
+    player.energy = 100
+    player.inventory.clear()
+    return player
+
+
+def test_schedule_requires_companion_and_morale():
+    player = make_player()
+    msg = schedule_companion_errand(player, 0)
+    assert msg == "No companion available"
+
+    player.companion = "Dog"
+    player.companion_level = 1
+    player.companion_morale = 20
+    msg = schedule_companion_errand(player, 0)
+    assert msg == "Companion morale too low"
+    assert player.money == 100
+
+
+def test_schedule_records_errand():
+    player = make_player()
+    player.companion = "Dog"
+    player.companion_level = 1
+    player.companion_morale = 80
+
+    message = schedule_companion_errand(player, 0)
+    assert "Dog" in message
+    assert player.money == 100 - COMPANION_ERRAND_FEE
+    assert len(player.companion_errands) == 1
+
+    errand = player.companion_errands[0]
+    assert errand["item_index"] == 0
+    assert errand["penalty"]["money"] >= 5
+
+
+def test_resolve_companion_errand_success(monkeypatch):
+    player = make_player()
+    player.companion = "Dog"
+    player.companion_level = 1
+    player.companion_morale = 80
+
+    schedule_companion_errand(player, 0)
+    monkeypatch.setattr(inventory.random, "random", lambda: 0.0)
+
+    messages = resolve_companion_errands(player)
+    assert any("fetched" in msg for msg in messages)
+    assert any(item.name == "Cola" for item in player.inventory)
+    assert not player.companion_errands
+    assert player.companion_morale >= 80
+
+
+def test_resolve_companion_errand_failure(monkeypatch):
+    player = make_player()
+    player.companion = "Dog"
+    player.companion_level = 1
+    player.companion_morale = 80
+
+    schedule_companion_errand(player, 0)
+    errand = player.companion_errands[0]
+    money_after_fee = player.money
+    morale_before = player.companion_morale
+    rep_before = player.reputation.get("mayor", 0)
+
+    monkeypatch.setattr(inventory.random, "random", lambda: 0.99)
+
+    messages = resolve_companion_errands(player)
+    assert any("failed" in msg for msg in messages)
+    assert player.money == max(0, money_after_fee - errand["penalty"]["money"])
+    assert player.companion_morale == max(0, morale_before - errand["penalty"]["morale"])
+    assert player.reputation["mayor"] == rep_before - errand["penalty"]["reputation"][1]
+    assert not player.inventory
+    assert not player.companion_errands


### PR DESCRIPTION
## Summary
- add companion errand tracking to the player and expose scheduling helpers
- resolve errands when the player sleeps with success rewards and failure penalties
- wire a pet shop errand menu into the interact key and cover the new logic with tests

## Testing
- pytest tests/test_inventory_errands.py

------
https://chatgpt.com/codex/tasks/task_e_68d29372703c8325a9d5744782271577