### PR TITLE
Refresh character and hazard SVGs

### DIFF
--- a/assets/images/enemy_0.svg
+++ b/assets/images/enemy_0.svg
@@ -1,9 +1,23 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='72' height='72' viewBox='0 0 72 72'>
-      <rect width='72' height='72' rx='12' fill='#ffe6e0'/>
-      <path d='M36 12 C18 16, 16 40, 28 52 C24 60, 18 60, 16 64 C28 64, 40 56, 44 44 C52 48, 60 40, 60 28 C60 16, 48 12, 36 12 Z' fill='#ff6f61' opacity='0.85'/>
-      <circle cx='30' cy='30' r='6' fill='#fff'/>
-      <circle cx='42' cy='30' r='6' fill='#fff'/>
-      <circle cx='30' cy='30' r='3' fill='#1b1b1b'/>
-      <circle cx='42' cy='30' r='3' fill='#1b1b1b'/>
-      <path d='M30 44 Q36 52 42 44' stroke='#1b1b1b' stroke-width='4' fill='none' stroke-linecap='round'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bgE0" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2f3d5f"/>
+      <stop offset="1" stop-color="#1b2336"/>
+    </linearGradient>
+    <linearGradient id="cloak0" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#596fa8"/>
+      <stop offset="1" stop-color="#2d3d63"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bgE0)" rx="8"/>
+  <circle cx="32" cy="20" r="12" fill="#2b2b2b" stroke="#0f131f" stroke-width="2"/>
+  <ellipse cx="27" cy="20" rx="3" ry="2.2" fill="#f45b69"/>
+  <ellipse cx="37" cy="20" rx="3" ry="2.2" fill="#f45b69"/>
+  <path d="M24 24q8 6 16 0" fill="none" stroke="#0f131f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M20 54q0-22 12-26t12 26" fill="url(#cloak0)" stroke="#10182b" stroke-width="2"/>
+  <path d="M22 30l-9 9" stroke="#10182b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M42 30l9 9" stroke="#10182b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M26 47l-6 13" stroke="#10182b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M38 47l6 13" stroke="#10182b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 36h10" stroke="#f0f5ff" stroke-width="2" stroke-linecap="round" opacity="0.5"/>
+</svg>

--- a/assets/images/enemy_1.svg
+++ b/assets/images/enemy_1.svg
@@ -1,9 +1,24 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='72' height='72' viewBox='0 0 72 72'>
-      <rect width='72' height='72' rx='12' fill='#d8f3dc'/>
-      <path d='M36 12 C18 16, 16 40, 28 52 C24 60, 18 60, 16 64 C28 64, 40 56, 44 44 C52 48, 60 40, 60 28 C60 16, 48 12, 36 12 Z' fill='#6a994e' opacity='0.85'/>
-      <circle cx='30' cy='30' r='6' fill='#fff'/>
-      <circle cx='42' cy='30' r='6' fill='#fff'/>
-      <circle cx='30' cy='30' r='3' fill='#1b1b1b'/>
-      <circle cx='42' cy='30' r='3' fill='#1b1b1b'/>
-      <path d='M30 44 Q36 52 42 44' stroke='#1b1b1b' stroke-width='4' fill='none' stroke-linecap='round'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bgE1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3b2626"/>
+      <stop offset="1" stop-color="#140b0b"/>
+    </linearGradient>
+    <linearGradient id="armor1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff9c3c"/>
+      <stop offset="1" stop-color="#c95a1f"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bgE1)" rx="8"/>
+  <circle cx="32" cy="18" r="11" fill="#2a1a1a" stroke="#0b0607" stroke-width="2"/>
+  <path d="M24 16q7-5 16 0" fill="none" stroke="#0b0607" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="27" cy="19" rx="2.5" ry="1.8" fill="#ffd166"/>
+  <ellipse cx="37" cy="19" rx="2.5" ry="1.8" fill="#ffd166"/>
+  <path d="M25 24q7 5 14 0" fill="none" stroke="#0b0607" stroke-width="2" stroke-linecap="round"/>
+  <path d="M19 52q2-20 26-16 4 3 4 16" fill="url(#armor1)" stroke="#611e11" stroke-width="2"/>
+  <path d="M22 29l-10 9" stroke="#611e11" stroke-width="3" stroke-linecap="round"/>
+  <path d="M42 29l10 9" stroke="#611e11" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 46l-7 13" stroke="#611e11" stroke-width="3" stroke-linecap="round"/>
+  <path d="M37 46l7 13" stroke="#611e11" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 35h10" stroke="#ffe4be" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/assets/images/enemy_2.svg
+++ b/assets/images/enemy_2.svg
@@ -1,9 +1,24 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='72' height='72' viewBox='0 0 72 72'>
-      <rect width='72' height='72' rx='12' fill='#dce8ff'/>
-      <path d='M36 12 C18 16, 16 40, 28 52 C24 60, 18 60, 16 64 C28 64, 40 56, 44 44 C52 48, 60 40, 60 28 C60 16, 48 12, 36 12 Z' fill='#577590' opacity='0.85'/>
-      <circle cx='30' cy='30' r='6' fill='#fff'/>
-      <circle cx='42' cy='30' r='6' fill='#fff'/>
-      <circle cx='30' cy='30' r='3' fill='#1b1b1b'/>
-      <circle cx='42' cy='30' r='3' fill='#1b1b1b'/>
-      <path d='M30 44 Q36 52 42 44' stroke='#1b1b1b' stroke-width='4' fill='none' stroke-linecap='round'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bgE2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1d2d1d"/>
+      <stop offset="1" stop-color="#0d140d"/>
+    </linearGradient>
+    <linearGradient id="armor2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#64d298"/>
+      <stop offset="1" stop-color="#2a7f57"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bgE2)" rx="8"/>
+  <circle cx="32" cy="19" r="11" fill="#1a241a" stroke="#061006" stroke-width="2"/>
+  <path d="M23 18q9-7 18 0" fill="none" stroke="#061006" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="27" cy="20" rx="2.4" ry="1.7" fill="#9bffd4"/>
+  <ellipse cx="37" cy="20" rx="2.4" ry="1.7" fill="#9bffd4"/>
+  <path d="M24 24q8 6 16 0" fill="none" stroke="#061006" stroke-width="2" stroke-linecap="round"/>
+  <path d="M20 52q3-18 13-20t11 20" fill="url(#armor2)" stroke="#10462c" stroke-width="2"/>
+  <path d="M22 30l-10 8" stroke="#10462c" stroke-width="3" stroke-linecap="round"/>
+  <path d="M42 30l10 8" stroke="#10462c" stroke-width="3" stroke-linecap="round"/>
+  <path d="M28 46l-6 13" stroke="#10462c" stroke-width="3" stroke-linecap="round"/>
+  <path d="M36 46l6 13" stroke="#10462c" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 36h10" stroke="#caffeb" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/assets/images/player_0.svg
+++ b/assets/images/player_0.svg
@@ -1,10 +1,25 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'>
-      <rect width='64' height='64' fill='#f4f7fb'/>
-      <circle cx='32' cy='20' r='10' fill='#f7d7b1' stroke='#333' stroke-width='2'/>
-      <rect x='27' y='30' width='10' height='18' rx='4' fill='#4a90e2' stroke='#333' stroke-width='2'/>
-      <line x1='32' y1='30' x2='18' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='30' x2='46' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='22' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='42' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <circle cx='32' cy='46' r='6' fill='#4a90e2' stroke='#333' stroke-width='2'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg0" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f8fbff"/>
+      <stop offset="1" stop-color="#dbe9ff"/>
+    </linearGradient>
+    <linearGradient id="suit0" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4a90e2"/>
+      <stop offset="1" stop-color="#1f64c8"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bg0)" rx="8"/>
+  <circle cx="32" cy="18" r="11" fill="#f6d2a4" stroke="#2f2f2f" stroke-width="2"/>
+  <path d="M25 16q2-5 7-5t7 5" fill="none" stroke="#2f2f2f" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="27" cy="19" r="1.5" fill="#2f2f2f"/>
+  <circle cx="37" cy="19" r="1.5" fill="#2f2f2f"/>
+  <path d="M27 24q5 4 10 0" fill="none" stroke="#2f2f2f" stroke-width="2" stroke-linecap="round"/>
+  <path d="M21 52q2-16 11-16t11 16" fill="url(#suit0)" stroke="#1e2f48" stroke-width="2"/>
+  <path d="M22 32l-9 7" stroke="#1e2f48" stroke-width="3" stroke-linecap="round"/>
+  <path d="M42 32l9 7" stroke="#1e2f48" stroke-width="3" stroke-linecap="round"/>
+  <path d="M28 48l-7 11" stroke="#1e2f48" stroke-width="3" stroke-linecap="round"/>
+  <path d="M36 48l7 11" stroke="#1e2f48" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="32" cy="36" r="6" fill="#1e2f48" opacity="0.15"/>
+  <path d="M30 36h4" stroke="#f1f5ff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/assets/images/player_1.svg
+++ b/assets/images/player_1.svg
@@ -1,10 +1,25 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'>
-      <rect width='64' height='64' fill='#f4f7fb'/>
-      <circle cx='32' cy='20' r='10' fill='#f7d7b1' stroke='#333' stroke-width='2'/>
-      <rect x='27' y='30' width='10' height='18' rx='4' fill='#50e3c2' stroke='#333' stroke-width='2'/>
-      <line x1='32' y1='30' x2='18' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='30' x2='46' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='22' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='42' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <circle cx='32' cy='46' r='6' fill='#50e3c2' stroke='#333' stroke-width='2'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fff8f8"/>
+      <stop offset="1" stop-color="#ffd9cf"/>
+    </linearGradient>
+    <linearGradient id="suit1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ff6b6b"/>
+      <stop offset="1" stop-color="#c83d54"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bg1)" rx="8"/>
+  <circle cx="32" cy="17" r="11" fill="#f2c89f" stroke="#2b1b1b" stroke-width="2"/>
+  <path d="M24 14c2-4 14-4 16 0" fill="none" stroke="#2b1b1b" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="27" cy="18" r="1.5" fill="#2b1b1b"/>
+  <circle cx="37" cy="18" r="1.5" fill="#2b1b1b"/>
+  <path d="M27 23q5 3 10 0" fill="none" stroke="#2b1b1b" stroke-width="2" stroke-linecap="round"/>
+  <path d="M20 52c1-15 24-15 25 0" fill="url(#suit1)" stroke="#541f2a" stroke-width="2"/>
+  <path d="M22 30l-10 9" stroke="#541f2a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M42 30l10 9" stroke="#541f2a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M30 46l-8 13" stroke="#541f2a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M34 46l8 13" stroke="#541f2a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M27 35h10" stroke="#ffe6ec" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="32" cy="36" r="6" fill="#541f2a" opacity="0.12"/>
+</svg>

--- a/assets/images/player_2.svg
+++ b/assets/images/player_2.svg
@@ -1,10 +1,25 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'>
-      <rect width='64' height='64' fill='#f4f7fb'/>
-      <circle cx='32' cy='20' r='10' fill='#f7d7b1' stroke='#333' stroke-width='2'/>
-      <rect x='27' y='30' width='10' height='18' rx='4' fill='#f5a623' stroke='#333' stroke-width='2'/>
-      <line x1='32' y1='30' x2='18' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='30' x2='46' y2='40' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='22' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <line x1='32' y1='48' x2='42' y2='60' stroke='#333' stroke-width='3' stroke-linecap='round'/>
-      <circle cx='32' cy='46' r='6' fill='#f5a623' stroke='#333' stroke-width='2'/>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f8f5ff"/>
+      <stop offset="1" stop-color="#e1d7ff"/>
+    </linearGradient>
+    <linearGradient id="suit2" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#a577ff"/>
+      <stop offset="1" stop-color="#6133d8"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="url(#bg2)" rx="8"/>
+  <circle cx="32" cy="18" r="11" fill="#f5d3af" stroke="#332d46" stroke-width="2"/>
+  <path d="M23 16c3-5 15-5 18 0" fill="none" stroke="#332d46" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="27" cy="20" r="1.5" fill="#332d46"/>
+  <circle cx="37" cy="20" r="1.5" fill="#332d46"/>
+  <path d="M27 25q5 3 10 0" fill="none" stroke="#332d46" stroke-width="2" stroke-linecap="round"/>
+  <path d="M22 51q3-17 20-12 4 2 4 12" fill="url(#suit2)" stroke="#2f2059" stroke-width="2"/>
+  <path d="M24 31l-10 8" stroke="#2f2059" stroke-width="3" stroke-linecap="round"/>
+  <path d="M40 31l10 8" stroke="#2f2059" stroke-width="3" stroke-linecap="round"/>
+  <path d="M29 47l-7 12" stroke="#2f2059" stroke-width="3" stroke-linecap="round"/>
+  <path d="M35 47l7 12" stroke="#2f2059" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="32" cy="36" r="6" fill="#2f2059" opacity="0.13"/>
+  <path d="M29.5 35.5h5" stroke="#efe9ff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/assets/images/puzzle.svg
+++ b/assets/images/puzzle.svg
@@ -1,7 +1,21 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96' viewBox='0 0 96 96'>
-  <rect width='96' height='96' rx='12' fill='#f1faee'/>
-  <path d='M20 48 h16 a8 8 0 0 1 8 8 v20 h-24 z' fill='#457b9d'/>
-  <path d='M44 20 v16 a8 8 0 0 0 8 8 h20 v-24 z' fill='#1d3557'/>
-  <path d='M56 68 a8 8 0 0 1 8 -8 h12 v24 h-20 z' fill='#a8dadc'/>
-  <circle cx='36' cy='36' r='6' fill='#fefae0'/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="puzzleBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f2f8ff"/>
+      <stop offset="1" stop-color="#d5e2ff"/>
+    </linearGradient>
+    <linearGradient id="pieceA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#60b4ff"/>
+      <stop offset="1" stop-color="#1f7be5"/>
+    </linearGradient>
+    <linearGradient id="pieceB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffcf66"/>
+      <stop offset="1" stop-color="#ffa23a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="url(#puzzleBg)"/>
+  <path d="M18 18h14a4 4 0 0 1 0 8h-2a4 4 0 0 0 0 8h2v14H18a4 4 0 0 1-4-4V22a4 4 0 0 1 4-4z" fill="url(#pieceA)" stroke="#20508f" stroke-width="2"/>
+  <path d="M46 46H32a4 4 0 0 1 0-8h2a4 4 0 0 0 0-8h-2V16h14a4 4 0 0 1 4 4v24a4 4 0 0 1-4 4z" fill="url(#pieceB)" stroke="#8a520f" stroke-width="2"/>
+  <path d="M26 48h12" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M24 16h16" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/assets/images/trap.svg
+++ b/assets/images/trap.svg
@@ -1,6 +1,21 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96' viewBox='0 0 96 96'>
-  <rect width='96' height='96' rx='12' fill='#ffe8cc'/>
-  <polygon points='16,72 48,16 80,72' fill='#d62828'/>
-  <line x1='16' y1='72' x2='80' y2='72' stroke='#1d3557' stroke-width='6' stroke-linecap='round'/>
-  <circle cx='48' cy='60' r='10' fill='#f4f1de'/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="trapBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f3136"/>
+      <stop offset="1" stop-color="#0f1113"/>
+    </linearGradient>
+    <linearGradient id="trapGlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ff8a5c"/>
+      <stop offset="1" stop-color="#ff4242"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="url(#trapBg)"/>
+  <g stroke="#1a1c1f" stroke-width="2" stroke-linecap="round" fill="none">
+    <path d="M10 44l10-24 12 24 12-24 10 24"/>
+    <path d="M14 46h36"/>
+  </g>
+  <circle cx="32" cy="24" r="10" fill="url(#trapGlow)" opacity="0.85"/>
+  <path d="M32 16v16" stroke="#fff0e0" stroke-width="2" stroke-linecap="round"/>
+  <path d="M24 24h16" stroke="#fff0e0" stroke-width="2" stroke-linecap="round"/>
+  <path d="M19 52h26" stroke="#ff8a5c" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
 </svg>


### PR DESCRIPTION
## Summary
- restyle the player and enemy character SVG portraits with gradients, richer outfits, and expressive facial details
- add depth and glow to trap and puzzle icons to better match the updated art direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a4a79b3c8325b0fcdf3de1037172