### PR TITLE
Expand fishing progression and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ still offers a daily puzzle for a small money reward, and you can dig for
 buried treasure on the beach. Lucky diggers might uncover a **Golden Seashell**
 decoration or a stylish **Pearl Necklace**.
 
+Fishing now includes its own progression system. Each cast grants fishing
+experience that levels up your angling skill, unlocking tougher fish with
+better payouts and reducing empty-hook casts. Every species you land is logged
+with its heaviest weight so you can chase new records, and rare treasure carp
+can even cough up casino tokens alongside their cash value.
+
 Weather now changes each day with rain or snow possible. The world cycles
 through Spring, Summer, Fall, and Winter, each lasting about a month.
 Bad weather closes the park and deal spots, and special seasonal encounters

--- a/entities.py
+++ b/entities.py
@@ -158,6 +158,11 @@ class Player:
     # Active deck used for card duels (up to 30 card names)
     deck: List[str] = field(default_factory=list)
 
+    # Fishing progression and records
+    fishing_skill: int = 1
+    fishing_exp: int = 0
+    fishing_log: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
     # Current honorific title earned through achievements
     epithet: str = ""
 

--- a/tests/test_minigames.py
+++ b/tests/test_minigames.py
@@ -35,10 +35,41 @@ def test_blackjack_perfect_score_unlocks_rewards():
 def test_fishing_hard_big_catch_rewards():
     player = make_player()
     player.energy = 50
+    player.fishing_skill = 3
+    king_salmon = {
+        "name": "King Salmon",
+        "rarity": 0.3,
+        "money_range": (30, 30),
+        "xp": 26,
+        "weight_divisor": 2.5,
+        "requires_level": 3,
+    }
     with patch('random.random', side_effect=[0.6, 0.6]):
-        with patch('random.randint', return_value=30):
+        with patch('helpers._choose_fishing_result', return_value=king_salmon):
             msg = go_fishing(player, difficulty='hard')
-    assert msg.startswith("Caught a fish")
+    assert msg.startswith("Caught a King Salmon")
     assert player.money >= 30
     assert "Master Angler" in player.achievements
     assert "Fishing Legend" in player.cards
+    assert player.fishing_log["King Salmon"]["count"] == 1
+
+
+def test_fishing_levels_up_and_logs_records():
+    player = make_player()
+    player.energy = 50
+    trout = {
+        "name": "River Trout",
+        "rarity": 0.45,
+        "money_range": (15, 15),
+        "xp": 50,
+        "weight_divisor": 4,
+    }
+    with patch('random.random', side_effect=[0.6, 0.6]):
+        with patch('helpers._choose_fishing_result', return_value=trout):
+            msg = go_fishing(player, difficulty='normal')
+    assert player.fishing_skill == 2
+    assert player.fishing_exp == 10
+    assert "Fishing level up" in msg
+    log = player.fishing_log["River Trout"]
+    assert log["count"] == 1
+    assert log["best_reward"] >= 15


### PR DESCRIPTION
## Summary
- add a fishing progression system with new loot tables, XP gains, and rare rewards
- persist the new fishing data and document the enhanced activity
- extend minigame tests to cover fishing level ups and record keeping

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9503f990c832590bfef457aa7ea1f