### PR TITLE
Add park upgrade system and fishing bonuses

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -163,6 +163,9 @@ class Player:
     fishing_exp: int = 0
     fishing_log: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
+    # Upgrades purchased for the park fishing minigame
+    park_upgrades: List[str] = field(default_factory=list)
+
     # Current honorific title earned through achievements
     epithet: str = ""
 

--- a/inventory.py
+++ b/inventory.py
@@ -164,6 +164,13 @@ HOME_UPGRADES: List[Tuple[str, int, str, int]] = [
     ("Private Library", 450, "Gain +2 INT each morning", 3),
 ]
 
+# Improvements that can be purchased for the city park
+PARK_UPGRADES: List[Tuple[str, int, str]] = [
+    ("Fishing Pier", 200, "Reduces empty casts when fishing"),
+    ("Bait Shack", 180, "Adds cash and XP to successful catches"),
+    ("Heated Pavilion", 350, "Keeps the park open during storms and winter"),
+]
+
 # Animal companions available at the Pet Shop
 COMPANIONS = [
     ("Dog", 120, "DEF +1, may find $5 when you sleep"),
@@ -400,6 +407,27 @@ def buy_home_upgrade(player: Player, index: int) -> str:
     elif name == "Mansion":
         player.home_level = 3
     return f"Bought {name}"
+
+
+def buy_park_upgrade(player: Player, index: int) -> str:
+    """Purchase a park improvement if affordable and not already owned."""
+
+    if index < 0 or index >= len(PARK_UPGRADES):
+        return "Invalid upgrade"
+    name, cost, _desc = PARK_UPGRADES[index]
+    if name in player.park_upgrades:
+        return "Already owned"
+    if player.money < cost:
+        return "Not enough money!"
+    player.money -= cost
+    player.park_upgrades.append(name)
+    return f"Built {name}"
+
+
+def available_park_upgrades(player: Player) -> List[Tuple[str, int, str]]:
+    """Return park upgrades that the player has not yet purchased."""
+
+    return [u for u in PARK_UPGRADES if u[0] not in player.park_upgrades]
 
 
 def available_home_upgrades(player: Player):


### PR DESCRIPTION
## Summary
- add persistent park upgrades to the player model and serialization
- implement purchasable park improvements that modify fishing odds and park availability
- cover the new upgrade flow and fishing bonuses with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd64e707288325a2911a9aff70f2c3